### PR TITLE
Auto indent

### DIFF
--- a/public/coffee/ide/editor/directives/aceEditor/auto-complete/Snippets.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/auto-complete/Snippets.coffee
@@ -1,6 +1,6 @@
 define () ->
 	environments = [
-		"abstract", 
+		"abstract",
 		"align", "align*",
 		"equation", "equation*",
 		"gather", "gather*",
@@ -14,7 +14,7 @@ define () ->
 			caption: "\\begin{#{env}}..."
 			snippet: """
 				\\begin{#{env}}
-				$1
+				\t$1
 				\\end{#{env}}
 			"""
 			meta: "env"
@@ -24,8 +24,8 @@ define () ->
 		caption: "\\begin{array}..."
 		snippet: """
 			\\begin{array}{${1:cc}}
-			$2 & $3 \\\\\\\\
-			$4 & $5
+			\t$2 & $3 \\\\\\\\
+			\t$4 & $5
 			\\end{array}
 		"""
 		meta: "env"
@@ -33,10 +33,10 @@ define () ->
 		caption: "\\begin{figure}..."
 		snippet: """
 			\\begin{figure}
-			\\centering
-			\\includegraphics{$1}
-			\\caption{${2:Caption}}
-			\\label{${3:fig:my_label}}
+			\t\\centering
+			\t\\includegraphics{$1}
+			\t\\caption{${2:Caption}}
+			\t\\label{${3:fig:my_label}}
 			\\end{figure}
 		"""
 		meta: "env"
@@ -44,8 +44,8 @@ define () ->
 		caption: "\\begin{tabular}..."
 		snippet: """
 			\\begin{tabular}{${1:c|c}}
-			$2 & $3 \\\\\\\\
-			$4 & $5
+			\t$2 & $3 \\\\\\\\
+			\t$4 & $5
 			\\end{tabular}
 		"""
 		meta: "env"
@@ -53,13 +53,13 @@ define () ->
 		caption: "\\begin{table}..."
 		snippet: """
 			\\begin{table}[$1]
-			\\centering
-			\\begin{tabular}{${2:c|c}}
-			$3 & $4 \\\\\\\\
-			$5 & $6
-			\\end{tabular}
-			\\caption{${7:Caption}}
-			\\label{${8:tab:my_label}}
+			\t\\centering
+			\t\\begin{tabular}{${2:c|c}}
+			\t\t$3 & $4 \\\\\\\\
+			\t\t$5 & $6
+			\t\\end{tabular}
+			\t\\caption{${7:Caption}}
+			\t\\label{${8:tab:my_label}}
 			\\end{table}
 		"""
 		meta: "env"
@@ -67,7 +67,7 @@ define () ->
 		caption: "\\begin{list}..."
 		snippet: """
 			\\begin{list}
-			\\item $1
+			\t\\item $1
 			\\end{list}
 		"""
 		meta: "env"
@@ -75,7 +75,7 @@ define () ->
 		caption: "\\begin{enumerate}..."
 		snippet: """
 			\\begin{enumerate}
-			\\item $1
+			\t\\item $1
 			\\end{enumerate}
 		"""
 		meta: "env"
@@ -83,7 +83,7 @@ define () ->
 		caption: "\\begin{itemize}..."
 		snippet: """
 			\\begin{itemize}
-			\\item $1
+			\t\\item $1
 			\\end{itemize}
 		"""
 		meta: "env"
@@ -91,7 +91,7 @@ define () ->
 		caption: "\\begin{frame}..."
 		snippet: """
 			\\begin{frame}{${1:Frame Title}}
-			$2
+			\t$2
 			\\end{frame}
 		"""
 		meta: "env"

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -230,7 +230,7 @@ oop.inherits(Mode, TextMode);
 
         var match = line.match(/^\s*\\end.*\s*$/);
 
-        var unbalanced =  (line.match(/\{/g) || []).length < (line.match(/\}/g)  || []).length ||
+      var unbalanced =  (line.match(/\{/g) || []).length < (line.match(/\}/g)  || []).length && ! line.match(/^\s*[\}]\s*/) ||
                           (line.match(/\(/g) || []).length < (line.match(/\)/g)  || []).length ||
                           (line.match(/\[/g) || []).length < (line.match(/\]/g)  || []).length;
 

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -215,7 +215,6 @@ var LatexHighlightRules = require("./latex_highlight_rules").LatexHighlightRules
 var LatexFoldMode = require("./folding/latex").FoldMode;
 var Range = require("../range").Range;
 
-
 var Mode = function() {
     this.HighlightRules = LatexHighlightRules;
 
@@ -227,6 +226,7 @@ oop.inherits(Mode, TextMode);
 
 (function() {
 
+    this.type = "text";
     this.lineCommentStart = "%";
     this.blockComment = {start: "\\begin{comment}", end: "\\end{comment}"};
 
@@ -273,4 +273,5 @@ oop.inherits(Mode, TextMode);
 }).call(Mode.prototype);
 
 exports.Mode = Mode;
+
 });

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -231,8 +231,8 @@ oop.inherits(Mode, TextMode);
         var match = line.match(/^\s*\\end.*\s*$/);
 
       var unbalanced =  (line.match(/\{/g) || []).length < (line.match(/\}/g)  || []).length && ! line.match(/^\s*[\}]\s*/) ||
-                          (line.match(/\(/g) || []).length < (line.match(/\)/g)  || []).length ||
-                          (line.match(/\[/g) || []).length < (line.match(/\]/g)  || []).length;
+                        (line.match(/\(/g) || []).length < (line.match(/\)/g)  || []).length && ! line.match(/^\s*[\)]\s*/) ||
+                        (line.match(/\[/g) || []).length < (line.match(/\]/g)  || []).length && ! line.match(/^\s*[\]]\s*/);
 
         if(match || unbalanced) {
           return true;

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -196,8 +196,6 @@ oop.inherits(Mode, TextMode);
         if (state == "start") {
             var match = line.match(/^\s*\\begin.*\s*$/);
 
-            var unbalanced = (line.match(/o/g) || []).length;
-
             var unbalanced =  (line.match(/\{/g) || []).length > (line.match(/\}/g)  || []).length ||
                               (line.match(/\(/g) || []).length > (line.match(/\)/g)  || []).length ||
                               (line.match(/\[/g) || []).length > (line.match(/\]/g)  || []).length;
@@ -222,13 +220,12 @@ oop.inherits(Mode, TextMode);
 
         if (!tokens)
             return false;
+        do {
+            var last = tokens.pop();
+        } while (last && (last.type == "comment" || (last.type == "text" && last.value.match(/^\s+$/))));
 
-        // do {
-        //     var last = tokens.pop();
-        // } while (last && (last.type == "comment" || (last.type == "text" && last.value.match(/^\s+$/))));
-        //
-        // if (!last)
-        //     return false;
+        if (!last)
+            return false;
 
 
         var match = line.match(/^\s*\\end.*\s*$/);

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -194,9 +194,15 @@ oop.inherits(Mode, TextMode);
         }
 
         if (state == "start") {
-            var match = line.match(/^\s*(\\begin|(.*\{(?!.*\})|\((?!.*\))|\[(?!.*\])|\:)).*\s*$/);
+            var match = line.match(/^\s*\\begin.*\s*$/);
 
-            if (match) {
+            var unbalanced = (line.match(/o/g) || []).length;
+
+            var unbalanced =  (line.match(/\{/g) || []).length > (line.match(/\}/g)  || []).length ||
+                              (line.match(/\(/g) || []).length > (line.match(/\)/g)  || []).length ||
+                              (line.match(/\[/g) || []).length > (line.match(/\]/g)  || []).length;
+
+            if (match || unbalanced) {
                 indent += tab;
             }
         }
@@ -216,16 +222,22 @@ oop.inherits(Mode, TextMode);
 
         if (!tokens)
             return false;
-        do {
-            var last = tokens.pop();
-        } while (last && (last.type == "comment" || (last.type == "text" && last.value.match(/^\s+$/))));
 
-        if (!last)
-            return false;
+        // do {
+        //     var last = tokens.pop();
+        // } while (last && (last.type == "comment" || (last.type == "text" && last.value.match(/^\s+$/))));
+        //
+        // if (!last)
+        //     return false;
 
-        var match = line.match(/^\s*(\\end.*|.*[\}\)\]])\s*$/);
 
-        if(match) {
+        var match = line.match(/^\s*\\end.*\s*$/);
+
+        var unbalanced =  (line.match(/\{/g) || []).length < (line.match(/\}/g)  || []).length ||
+                          (line.match(/\(/g) || []).length < (line.match(/\)/g)  || []).length ||
+                          (line.match(/\[/g) || []).length < (line.match(/\]/g)  || []).length;
+
+        if(match || unbalanced) {
           return true;
         }
 

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -228,7 +228,6 @@ oop.inherits(Mode, TextMode);
 
     this.type = "text";
     this.lineCommentStart = "%";
-    this.blockComment = {start: "\\begin{comment}", end: "\\end{comment}"};
 
     this.getNextLineIndent = function(state, line, tab) {
         var indent = this.$getIndent(line);

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -194,7 +194,7 @@ oop.inherits(Mode, TextMode);
         }
 
         if (state == "start") {
-            var match = line.match(/^\s*(\\begin|.*\{).*\s*$/);
+            var match = line.match(/^\s*(\\begin|(.*\{(?!.*\})|\((?!.*\))|\[(?!.*\])|\:)).*\s*$/);
 
             if (match) {
                 indent += tab;
@@ -223,7 +223,7 @@ oop.inherits(Mode, TextMode);
         if (!last)
             return false;
 
-        var match = line.match(/^\s*\\end.*\s*$/);
+        var match = line.match(/^\s*(\\end.*|.*[\}\)\]])\s*$/);
 
         if(match) {
           return true;

--- a/public/js/ace/mode-latex.js
+++ b/public/js/ace/mode-latex.js
@@ -230,9 +230,9 @@ oop.inherits(Mode, TextMode);
 
         var match = line.match(/^\s*\\end.*\s*$/);
 
-      var unbalanced =  (line.match(/\{/g) || []).length < (line.match(/\}/g)  || []).length && ! line.match(/^\s*[\}]\s*/) ||
-                        (line.match(/\(/g) || []).length < (line.match(/\)/g)  || []).length && ! line.match(/^\s*[\)]\s*/) ||
-                        (line.match(/\[/g) || []).length < (line.match(/\]/g)  || []).length && ! line.match(/^\s*[\]]\s*/);
+        var unbalanced =  (line.match(/\{/g) || []).length < (line.match(/\}/g)  || []).length && ! line.match(/^\s*[\}]\s*/) ||
+                          (line.match(/\(/g) || []).length < (line.match(/\)/g)  || []).length && ! line.match(/^\s*[\)]\s*/) ||
+                          (line.match(/\[/g) || []).length < (line.match(/\]/g)  || []).length && ! line.match(/^\s*[\]]\s*/);
 
         if(match || unbalanced) {
           return true;


### PR DESCRIPTION
This is the first half of a feature I requested in [Issue #152](https://github.com/sharelatex/sharelatex/issues/152). I mentioned using `latexindent.pl` to "beautify" an entire LaTeX document with a keyboard shortcut. I am still working on that feature; I could probably make a JS function for ACE ([like this](http://jsfiddle.net/HD4uj/)) rather than execute `latexindent.pl` so the code runs clientside per @henryoswald's request.

This pull request implements auto-indenting while typing using ACE's auto indent and outdent feature. It auto-indents after instances of `\begin{...}` as well as when `{`,`(`, or `[` are not closed at the end of a line, and out-outdents before instances of `\end{...}` and with single `}` on a line. Auto indentation produces the following results, without using TAB or backspace for corrections:

```
\begin{filecontents}{mybib.bib}
    @online{
        strawberryperl,
        title="Strawberry Perl",
        url="..."
    }
    @online{
        cmhblog,
        title="A Perl script for...",
        url="..."
    }
\end{filecontents}
```

```
\tikzset{
    shrink inner sep/.code={
        \pgfkeysgetvalue...
        \pgfkeysgetvalue...
    }
}
```

```
\def\Picture#1{
    \def\stripH{#1}
    \begin{pspicture}[showgrid...]
        \psforeach{\row}{
            {{3,2,1}},
            {1,2,3},
            ...
        }{
            \expandafter...
        }
    \end{pspicture}
}
```

I also updated the autocomplete snippets so they are all indented properly when spawned.

This pull request edits a part of the ACE backend. I can submit a pull request to ACE too, if it's appropriate.
