### PR TITLE
use font-face for pdfjs rendering

### DIFF
--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -9,7 +9,7 @@ define [
 			JOB_QUEUE_INTERVAL: 25
 
 			constructor: (@url, @options) ->
-				PDFJS.disableFontFace = true  # avoids repaints, uses worker more
+				# PDFJS.disableFontFace = true  # avoids repaints, uses worker more
 				# PDFJS.disableAutoFetch = true # enable this to prevent loading whole file
 				# PDFJS.disableStream
 				# PDFJS.disableRange


### PR DESCRIPTION
For compatibility with pdfListView  I think we should switch back to using the browser font renderer to display the pdf.  It is a slower on rendering for figures, but does give nicer looking anti-aliased text.