### PR TITLE
Allowed scroll on binary-file container

### DIFF
--- a/public/stylesheets/app/editor/binary-file.less
+++ b/public/stylesheets/app/editor/binary-file.less
@@ -2,6 +2,7 @@
 	padding: @line-height-computed / 2;
 	background-color: @gray-lightest;
 	text-align: center;
+	overflow: auto;
 	img {
 		max-width: 100%;
 		max-height: 90%;


### PR DESCRIPTION
Trying to fix issue #124.
I set overflow in auto mode to allow large images. It seems to be the simplest way and the expected site comportment. 