### PR TITLE
Pdfng scrollhandler performance improvements

### DIFF
--- a/public/coffee/ide/pdfng/directives/pdfPage.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfPage.coffee
@@ -99,7 +99,7 @@ define [
 					highlights: highlightsElement
 				})
 
-				scope.$watch 'highlights', (highlights, oldVal) ->
+				scope.$on 'pdf:highlights', (event, highlights) ->
 					return unless highlights?
 					return unless highlights.length > 0
 					if scope.timeoutHandler

--- a/public/coffee/ide/pdfng/directives/pdfPage.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfPage.coffee
@@ -29,32 +29,16 @@ define [
 					canvasElement.width(w)
 					scope.page.sized = true
 
-				isVisible = (containerSize) ->
-					elemTop = element.offset().top - containerSize[2]
-					elemBottom = elemTop + element.innerHeight()
-					visible = (elemTop < containerSize[1] and elemBottom > 0)
-					scope.page.visible = visible
-					scope.page.elemTop = elemTop
-					scope.page.elemBottom = elemBottom
-					return visible
-
-				renderPage = () ->
-					scope.document.renderPage {
-						canvas: canvasElement,
-						text: textElement
-						annotations: annotationsElement
-						highlights: highlightsElement
-					}, scope.page.pageNum
-
-				pausePage = () ->
-					scope.document.pause {
-						canvas: canvasElement,
-						text: textElement
-					}, scope.page.pageNum
-
 				# keep track of our page element, so we can access it in the
-				# parent with scope.pages[i].element
+				# parent with scope.pages[i].element, and the contained
+				# elements for each part
 				scope.page.element = element
+				scope.page.elementChildren = {
+					canvas: canvasElement,
+					text: textElement
+					annotations: annotationsElement
+					highlights: highlightsElement
+				}
 
 				if !scope.page.sized
 					if scope.defaultPageSize?
@@ -69,22 +53,9 @@ define [
 
 				if scope.page.current
 						# console.log 'we must scroll to this page', scope.page.pageNum, 'at position', scope.page.position
-						renderPage()
 						# this is the current page, we want to scroll it into view
+						# FIXME: do we need to ensure render fires before moving to this position???
 						ctrl.setPdfPosition(scope.page, scope.page.position)
-
-				watchHandle = scope.$watch 'containerSize', (containerSize, oldVal) ->
-					return unless containerSize?
-					return unless scope.page.sized
-					oldVisible = scope.page.visible
-					newVisible = isVisible containerSize
-					scope.page.visible = newVisible
-					if newVisible && !oldVisible
-						renderPage()
-						# TODO deregister this listener after the page is rendered
-						#watchHandle()
-					else if !newVisible && oldVisible
-						pausePage()
 
 				element.on 'dblclick', (e) ->
 					offset = $(element).find('.pdf-canvas').offset()

--- a/public/coffee/ide/pdfng/directives/pdfPage.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfPage.coffee
@@ -38,6 +38,7 @@ define [
 					text: textElement
 					annotations: annotationsElement
 					highlights: highlightsElement
+					container: element
 				}
 
 				if !scope.page.sized

--- a/public/coffee/ide/pdfng/directives/pdfPage.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfPage.coffee
@@ -56,18 +56,22 @@ define [
 				# parent with scope.pages[i].element
 				scope.page.element = element
 
-				if (!scope.page.sized && scope.defaultPageSize)
-					updatePageSize scope.defaultPageSize
+				if !scope.page.sized
+					if scope.defaultPageSize?
+						updatePageSize scope.defaultPageSize
+					else
+						# shouldn't get here - the default page size should now
+						# always be set before redraw is called
+						handler = scope.$watch 'defaultPageSize', (defaultPageSize) ->
+							return unless defaultPageSize?
+							updatePageSize defaultPageSize
+							handler()
 
 				if scope.page.current
 						# console.log 'we must scroll to this page', scope.page.pageNum, 'at position', scope.page.position
 						renderPage()
 						# this is the current page, we want to scroll it into view
 						ctrl.setPdfPosition(scope.page, scope.page.position)
-
-				scope.$watch 'defaultPageSize', (defaultPageSize) ->
-					return unless defaultPageSize?
-					updatePageSize defaultPageSize
 
 				watchHandle = scope.$watch 'containerSize', (containerSize, oldVal) ->
 					return unless containerSize?

--- a/public/coffee/ide/pdfng/directives/pdfPage.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfPage.coffee
@@ -55,7 +55,8 @@ define [
 				if scope.page.current
 						# console.log 'we must scroll to this page', scope.page.pageNum, 'at position', scope.page.position
 						# this is the current page, we want to scroll it into view
-						# FIXME: do we need to ensure render fires before moving to this position???
+						# and render it immediately
+						scope.document.renderPage scope.page
 						ctrl.setPdfPosition(scope.page, scope.page.position)
 
 				element.on 'dblclick', (e) ->

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -90,13 +90,6 @@ define [
 			setScale: (@scale) ->
 				@resetState()
 
-			pause: (element, pagenum) ->
-				return if @complete[pagenum]
-				return if @shuttingDown
-				@renderQueue = @renderQueue.filter (q) ->
-					q.pagenum != pagenum
-				@spinner.stop(element.canvas)
-
 			triggerRenderQueue: (interval = @JOB_QUEUE_INTERVAL) ->
 				$timeout () =>
 					@processRenderQueue()
@@ -115,15 +108,6 @@ define [
 						'element': page.elementChildren
 						'pagenum': page.pageNum
 					}
-				@triggerRenderQueue()
-
-			renderPage: (element, pagenum) ->
-				return if @shuttingDown
-				current = {
-					'element': element
-					'pagenum': pagenum
-				}
-				@renderQueue.push(current)
 				@triggerRenderQueue()
 
 			processRenderQueue: () ->

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -131,7 +131,9 @@ define [
 				@jobs = @jobs + 1
 
 				element.canvas.addClass('pdfng-loading')
-				@spinner.add(element.canvas)
+				spinTimer = $timeout () =>
+					@spinner.add(element.canvas)
+				, 100
 
 				completeRef = @complete
 				renderTaskRef = @renderTask
@@ -142,6 +144,7 @@ define [
 					Raven.captureMessage?('pdfng page load timed out after ' + @PAGE_LOAD_TIMEOUT + 'ms')
 					# console.log 'page load timed out', pagenum
 					timedOut = true
+					$timeout.cancel(spinTimer)
 					@spinner.stop(element.canvas)
 					# @jobs = @jobs - 1
 					# @triggerRenderQueue(0)
@@ -153,6 +156,7 @@ define [
 				@pageLoad[pagenum].then (pageObject) =>
 					# console.log 'in page load success', pagenum
 					$timeout.cancel(timer)
+					$timeout.cancel(spinTimer)
 					@renderTask[pagenum] = @doRender element, pagenum, pageObject
 					@renderTask[pagenum].then () =>
 						# complete
@@ -166,6 +170,7 @@ define [
 				.catch (error) ->
 					# console.log 'in page load error', pagenum, 'timedOut=', timedOut
 					$timeout.cancel(timer)
+					$timeout.cancel(spinTimer)
 					# console.log 'ERROR', error
 
 			doRender: (element, pagenum, page) ->

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -110,6 +110,15 @@ define [
 					}
 				@triggerRenderQueue()
 
+			renderPage: (page) ->
+				return if @shuttingDown
+				current =		{
+					'element': page.elementChildren
+					'pagenum': page.pageNum
+				}
+				@renderQueue.push current
+				@processRenderQueue()
+
 			processRenderQueue: () ->
 				return if @shuttingDown
 				return if @jobs > 0

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -25,6 +25,7 @@ define [
 					pdfDocument.getDownloadInfo().then () =>
 						@options.loadedCallback()
 				@errorCallback = @options.errorCallback
+				@pageSizeChangeCallback = @options.pageSizeChangeCallback
 				@pdfjs.catch (exception) =>
 					# console.log 'ERROR in get document', exception
 					@errorCallback(exception)
@@ -216,8 +217,14 @@ define [
 				canvas.height(newHeight + 'px')
 				canvas.width(newWidth + 'px')
 
-				element.canvas.height(newHeight)
-				element.canvas.width(newWidth)
+				oldHeight = element.canvas.height()
+				oldWidth = element.canvas.width()
+				if newHeight != oldHeight  or  newWidth != oldWidth
+					element.canvas.height(newHeight + 'px')
+					element.canvas.width(newWidth + 'px')
+					element.container.height(newHeight + 'px')
+					element.container.width(newWidth + 'px')
+					@pageSizeChangeCallback?(pagenum, newHeight - oldHeight)
 
 				if pixelRatio != 1
 					ctx.scale(pixelRatio, pixelRatio)

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -107,6 +107,15 @@ define [
 				@jobs = @jobs - 1
 				@triggerRenderQueue(0)
 
+			renderPages: (pages) ->
+				return if @shuttingDown
+				@renderQueue = for page in pages
+					{
+						'element': page.elementChildren
+						'pagenum': page.pageNum
+					}
+				@triggerRenderQueue()
+
 			renderPage: (element, pagenum) ->
 				return if @shuttingDown
 				current = {

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -283,7 +283,7 @@ define [
 						ctrl.setScale(scale, h, w).then () ->
 							spinner.remove(element)
 							ctrl.redraw(origposition)
-							$timeout renderVisiblePages, 0
+							setTimeout renderVisiblePages, 0
 
 				checkElementReady = () ->
 					# if element is zero-sized keep checking until it is ready

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -452,6 +452,8 @@ define [
 
 					return if !highlights.length
 
+					scope.$broadcast 'pdf:highlights', areas
+
 					first = highlights[0]
 
 					pageNum = scope.pages[first.page].pageNum

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -40,6 +40,8 @@ define [
 				errorCallback: (error) ->
 					Raven.captureMessage?('pdfng error ' + error)
 					$scope.$emit 'pdf:error', error
+				pageSizeChangeCallback: (pageNum, deltaH) ->
+					$scope.$broadcast 'pdf:page:size-change', pageNum, deltaH
 			})
 
 			# we will have all the main information needed to start display
@@ -335,6 +337,16 @@ define [
 					ctrl.load()
 					# trigger a redraw
 					scope.scale = angular.copy (scope.scale)
+
+				scope.$on 'pdf:page:size-change', (event, pageNum, delta) ->
+					#console.log 'page size change event', pageNum, delta
+					origposition = angular.copy scope.position
+					#console.log 'orig position', JSON.stringify(origposition)
+					if pageNum - 1 < origposition.page && delta != 0
+						currentScrollTop =  element.scrollTop()
+						console.log 'adjusting scroll from', currentScrollTop, 'by', delta
+						scope.adjustingScroll = true
+						element.scrollTop(currentScrollTop + delta)
 
 				element.on 'scroll', () ->
 					#console.log 'scroll event', element.scrollTop(), 'adjusting?', scope.adjustingScroll

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -240,8 +240,8 @@ define [
 					# console.log 'layoutReady was resolved'
 
 				renderVisiblePages = () ->
-					visiblePages = getVisiblePages()
-					pages = getExtraPages visiblePages
+					pages = getVisiblePages()
+					# pages = getExtraPages visiblePages
 					scope.document.renderPages(pages)
 
 				getVisiblePages = () ->

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -245,8 +245,8 @@ define [
 					scope.document.renderPages(pages)
 
 				getVisiblePages = () ->
-					top = element[0].offsetTop
-					bottom = top + element[0].clientHeight
+					top = element[0].scrollTop;
+					bottom = top + element[0].clientHeight;
 					isVisible = (pageElement) ->
 						pageTop = pageElement.offsetTop
 						pageBottom = pageTop + pageElement.clientHeight

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -364,11 +364,11 @@ define [
 
 				scrollHandler = () ->
 					renderVisiblePages()
-					scope.$apply()
+					#scope.$apply()
 					newPosition = ctrl.getPdfPosition()
 					if newPosition?
 						scope.position = newPosition
-					scope.$apply()
+					#scope.$apply()
 					scope.scrollHandlerTimeout = null
 
 				scope.$watch 'pdfSrc', (newVal, oldVal) ->

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -359,8 +359,8 @@ define [
 						return
 					#scope.scrolled = true
 					if scope.scrollHandlerTimeout
-						$timeout.cancel(scope.scrollHandlerTimeout)
-					scope.scrollHandlerTimeout = $timeout scrollHandler, 25
+						clearTimeout(scope.scrollHandlerTimeout)
+					scope.scrollHandlerTimeout = setTimeout scrollHandler, 25
 
 				scrollHandler = () ->
 					renderVisiblePages()

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -247,14 +247,12 @@ define [
 				getVisiblePages = () ->
 					top = element[0].scrollTop;
 					bottom = top + element[0].clientHeight;
-					isVisible = (pageElement) ->
+					visiblePages = scope.pages.filter (page) ->
+						pageElement = page.element[0]
 						pageTop = pageElement.offsetTop
 						pageBottom = pageTop + pageElement.clientHeight
-						return pageTop < bottom and pageBottom > top
-					visiblePages = []
-					for page in scope.pages
-						page.visible = visible = isVisible(page.element[0])
-						visiblePages.push page if visible
+						page.visible = pageTop < bottom and pageBottom > top
+						return page.visible
 					return visiblePages
 
 				getExtraPages = (visiblePages) ->

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -245,15 +245,15 @@ define [
 					scope.document.renderPages(pages)
 
 				getVisiblePages = () ->
-					top = element.offset().top
-					bottom = top + element.innerHeight();
+					top = element[0].offsetTop
+					bottom = top + element[0].clientHeight
 					isVisible = (pageElement) ->
-						pageTop = pageElement.offset().top
-						pageBottom = pageTop + pageElement.innerHeight()
+						pageTop = pageElement.offsetTop
+						pageBottom = pageTop + pageElement.clientHeight
 						return pageTop < bottom and pageBottom > top
 					visiblePages = []
 					for page in scope.pages
-						page.visible = visible = isVisible(page.element)
+						page.visible = visible = isVisible(page.element[0])
 						visiblePages.push page if visible
 					return visiblePages
 

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -265,13 +265,13 @@ define [
 					lastVisiblePage = visiblePages[len-1].pageNum
 					lastVisiblePageIdx = lastVisiblePage - 1
 					# first page after
-					if lastVisiblePageIdx + 1 < len
+					if lastVisiblePageIdx + 1 < scope.pages.length
 						extra.push scope.pages[lastVisiblePageIdx + 1]
 					# page before
 					if firstVisiblePageIdx > 0
 						extra.push scope.pages[firstVisiblePageIdx - 1]
 					# second page after
-					if lastVisiblePageIdx + 2 < len
+					if lastVisiblePageIdx + 2 < scope.pages.length
 						extra.push scope.pages[lastVisiblePageIdx + 2]
 					return visiblePages.concat extra
 

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -344,7 +344,7 @@ define [
 					#console.log 'orig position', JSON.stringify(origposition)
 					if pageNum - 1 < origposition.page && delta != 0
 						currentScrollTop =  element.scrollTop()
-						console.log 'adjusting scroll from', currentScrollTop, 'by', delta
+						#console.log 'adjusting scroll from', currentScrollTop, 'by', delta
 						scope.adjustingScroll = true
 						element.scrollTop(currentScrollTop + delta)
 


### PR DESCRIPTION
To improve the scrollhandler performance there were several stages

- remove all per-page watchers and put the visibility calculation in the top-level viewer
- use setTimeout in the scrollhandler instead of $timeout (the latter triggers a digest which is expensive)
- in the visibility calculation use DOM methods to get positions instead of Jquery (this loop is executed a lot)
- debouce scroll events, so scrollhandler fires 25ms after user stops scrolling
- remove useless scope.apply's, since these trigger a digest