### PR TITLE
Fix performance

### DIFF
--- a/public/coffee/ide/directives/layout.coffee
+++ b/public/coffee/ide/directives/layout.coffee
@@ -103,12 +103,12 @@ define [
 
 					resetOpenStates()
 					onInternalResize()
-					
-					scope.$watch attrs.layoutDisabled, (value) ->
-						if value
-							element.layout().hide("east")
-						else
-							element.layout().show("east")
-							
+
+					if attrs.layoutDisabled?
+						scope.$watch attrs.layoutDisabled, (value) ->
+							if value
+								element.layout().hide("east")
+							else
+								element.layout().show("east")
 		}
 	]

--- a/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
+++ b/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
@@ -3,7 +3,7 @@ define [
 	"ide/editor/Document"
 ], (App, Document) ->
 	App.controller "SavingNotificationController", ["$scope", "$interval", "ide", ($scope, $interval, ide) ->
-		$interval () ->
+		setInterval () ->
 			pollSavedStatus()
 		, 1000
 
@@ -13,19 +13,23 @@ define [
 		$scope.docSavingStatus = {}
 		pollSavedStatus = () ->
 			oldStatus = $scope.docSavingStatus
-			$scope.docSavingStatus = {}
+			newStatus = {}
 
 			for doc_id, doc of Document.openDocs
 				saving = doc.pollSavedStatus()
 				if !saving
 					if oldStatus[doc_id]?
-						$scope.docSavingStatus[doc_id] = oldStatus[doc_id]
-						$scope.docSavingStatus[doc_id].unsavedSeconds += 1
+						newStatus[doc_id] = oldStatus[doc_id]
+						newStatus[doc_id].unsavedSeconds += 1
 					else
-						$scope.docSavingStatus[doc_id] = {
+						newStatus[doc_id] = {
 							unsavedSeconds: 0
 							doc: ide.fileTreeManager.findEntityById(doc_id)
 						}
+
+			if _.size(newStatus) or _.size(oldStatus)
+				$scope.docSavingStatus = newStatus
+				$scope.$apply()
 
 		warnAboutUnsavedChanges = () ->
 			if Document.hasUnsavedChanges()

--- a/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
+++ b/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
@@ -27,6 +27,8 @@ define [
 							doc: ide.fileTreeManager.findEntityById(doc_id)
 						}
 
+			# for performance, only update the display if the old or new
+			# statuses have any unsaved files
 			if _.size(newStatus) or _.size(oldStatus)
 				$scope.docSavingStatus = newStatus
 				$scope.$apply()

--- a/public/coffee/ide/editor/directives/aceEditor/highlights/HighlightsManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/highlights/HighlightsManager.coffee
@@ -106,8 +106,11 @@ define [
 					labelToShow = label
 
 			if !labelToShow?
-				@$scope.$apply () =>
-					@$scope.annotationLabel.show = false
+				# this is the most common path, triggered on mousemove, so
+				# for performance only apply setting when it changes
+				if @$scope?.annotationLabel?.show != false
+					@$scope.$apply () =>
+						@$scope.annotationLabel.show = false
 			else
 				$ace = $(@editor.renderer.container).find(".ace_scroller")
 				# Move the label into the Ace content area so that offsets and positions are easy to calculate.

--- a/public/coffee/ide/editor/directives/aceEditor/spell-check/SpellCheckManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/spell-check/SpellCheckManager.coffee
@@ -86,8 +86,11 @@ define [
 				return false
 
 		closeContextMenu: (e) ->
-			@$scope.$apply () =>
-				@$scope.spellingMenu.open = false
+			# this is triggered on scroll, so for performance only apply
+			# setting when it changes
+			if @$scope?.spellingMenu?.open != false
+				@$scope.$apply () =>
+					@$scope.spellingMenu.open = false
 
 		replaceWord: (highlight, text) ->
 			@editor.getSession().replace(new Range(


### PR DESCRIPTION
Avoid calling scope.$apply in the following cases

 - editor highlights (on mousemove in editor)
 - closing context menu (on scroll in editor)
 - background saved file check (every second)

Also fixes attrs.layoutDisabled watch on undefined.