### PR TITLE
Fix pdfng no background digests

### DIFF
--- a/public/coffee/ide/directives/layout.coffee
+++ b/public/coffee/ide/directives/layout.coffee
@@ -103,12 +103,12 @@ define [
 
 					resetOpenStates()
 					onInternalResize()
-					
-					scope.$watch attrs.layoutDisabled, (value) ->
-						if value
-							element.layout().hide("east")
-						else
-							element.layout().show("east")
-							
+
+					if attrs.layoutDisabled?
+						scope.$watch attrs.layoutDisabled, (value) ->
+							if value
+								element.layout().hide("east")
+							else
+								element.layout().show("east")
 		}
 	]

--- a/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
+++ b/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
@@ -3,7 +3,7 @@ define [
 	"ide/editor/Document"
 ], (App, Document) ->
 	App.controller "SavingNotificationController", ["$scope", "$interval", "ide", ($scope, $interval, ide) ->
-		$interval () ->
+		setInterval () ->
 			pollSavedStatus()
 		, 1000
 
@@ -13,19 +13,23 @@ define [
 		$scope.docSavingStatus = {}
 		pollSavedStatus = () ->
 			oldStatus = $scope.docSavingStatus
-			$scope.docSavingStatus = {}
+			newStatus = {}
 
 			for doc_id, doc of Document.openDocs
 				saving = doc.pollSavedStatus()
 				if !saving
 					if oldStatus[doc_id]?
-						$scope.docSavingStatus[doc_id] = oldStatus[doc_id]
-						$scope.docSavingStatus[doc_id].unsavedSeconds += 1
+						newStatus[doc_id] = oldStatus[doc_id]
+						newStatus[doc_id].unsavedSeconds += 1
 					else
-						$scope.docSavingStatus[doc_id] = {
+						newStatus[doc_id] = {
 							unsavedSeconds: 0
 							doc: ide.fileTreeManager.findEntityById(doc_id)
 						}
+
+			if _.size(newStatus) or _.size(oldStatus)
+				$scope.docSavingStatus = newStatus
+				$scope.$apply()
 
 		warnAboutUnsavedChanges = () ->
 			if Document.hasUnsavedChanges()

--- a/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
+++ b/public/coffee/ide/editor/controllers/SavingNotificationController.coffee
@@ -27,6 +27,8 @@ define [
 							doc: ide.fileTreeManager.findEntityById(doc_id)
 						}
 
+			# for performance, only update the display if the old or new
+			# statuses have any unsaved files
 			if _.size(newStatus) or _.size(oldStatus)
 				$scope.docSavingStatus = newStatus
 				$scope.$apply()

--- a/public/coffee/ide/editor/directives/aceEditor/highlights/HighlightsManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/highlights/HighlightsManager.coffee
@@ -106,8 +106,11 @@ define [
 					labelToShow = label
 
 			if !labelToShow?
-				@$scope.$apply () =>
-					@$scope.annotationLabel.show = false
+				# this is the most common path, triggered on mousemove, so
+				# for performance only apply setting when it changes
+				if @$scope?.annotationLabel?.show != false
+					@$scope.$apply () =>
+						@$scope.annotationLabel.show = false
 			else
 				$ace = $(@editor.renderer.container).find(".ace_scroller")
 				# Move the label into the Ace content area so that offsets and positions are easy to calculate.

--- a/public/coffee/ide/editor/directives/aceEditor/spell-check/SpellCheckManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/spell-check/SpellCheckManager.coffee
@@ -86,8 +86,11 @@ define [
 				return false
 
 		closeContextMenu: (e) ->
-			@$scope.$apply () =>
-				@$scope.spellingMenu.open = false
+			# this is triggered on scroll, so for performance only apply
+			# setting when it changes
+			if @$scope?.spellingMenu?.open != false
+				@$scope.$apply () =>
+					@$scope.spellingMenu.open = false
 
 		replaceWord: (highlight, text) ->
 			@editor.getSession().replace(new Range(

--- a/public/coffee/ide/pdfng/directives/pdfJs.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfJs.coffee
@@ -94,6 +94,7 @@ define [
 					$timeout () ->
 						scope.loading = false
 						delete scope.progress
+					, 250
 
 				#scope.$watch "highlights", (areas) ->
 					# console.log 'got HIGHLIGHTS in pdfJS', areas

--- a/public/coffee/ide/pdfng/directives/pdfJs.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfJs.coffee
@@ -81,7 +81,6 @@ define [
 						# console.log 'pdfSrc =', url
 						initializePosition()
 						flashControls()
-						scope.$broadcast 'layout-ready'
 						# pdfListView
 						#		.loadPdf(url, onProgress)
 						#		.then () ->

--- a/public/coffee/ide/pdfng/directives/pdfJs.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfJs.coffee
@@ -63,10 +63,11 @@ define [
 						$.localStorage "pdf.position.#{attrs.key}", scope.position
 
 				flashControls = () ->
-					scope.flashControls = true
-					$timeout () ->
-						scope.flashControls = false
-					, 1000
+					scope.$evalAsync () ->
+						scope.flashControls = true
+						$timeout () ->
+							scope.flashControls = false
+						, 1000
 
 				scope.$on 'pdfDoubleClick', (event, e) ->
 					scope.dblClickCallback?(page: e.page - 1, offset: { top: e.y, left: e.x })
@@ -91,8 +92,9 @@ define [
 						#				flashControls()
 				
 				scope.$on "loaded", () ->
-					scope.loading = false
-					delete scope.progress
+					$timeout () ->
+						scope.loading = false
+						delete scope.progress
 
 				#scope.$watch "highlights", (areas) ->
 					# console.log 'got HIGHLIGHTS in pdfJS', areas
@@ -155,8 +157,12 @@ define [
 
 				scope.$on 'progress', (event, progress) ->
 					scope.$apply () ->
-						#console.log 'progress', progress.loaded, progress.total, progress
 						scope.progress = Math.floor(progress.loaded/progress.total*100)
+						scope.progress = 100 if scope.progress > 100
+						scope.progress = 0 if scope.progress < 0
+
+				scope.$on '$destroy', () ->
+					# console.log 'pdfjs destroy event'
 
 			template: """
 				<div data-pdf-viewer class="pdfjs-viewer" pdf-src='pdfSrc' position='position' scale='scale' highlights='highlights' please-jump-to='pleaseJumpTo'></div>

--- a/public/coffee/ide/pdfng/directives/pdfJs.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfJs.coffee
@@ -91,6 +91,8 @@ define [
 						#				flashControls()
 				
 				scope.$on "loaded", () ->
+					scope.progress = 100
+					scope.$apply()
 					$timeout () ->
 						scope.loading = false
 						delete scope.progress

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -49,11 +49,11 @@ define [
 
 			getPdfViewport: (pageNum, scale) ->
 				scale ?= @scale
-				@document.then (pdfDocument) ->
+				@document.then (pdfDocument) =>
 					pdfDocument.getPage(pageNum).then (page) ->
 						viewport = page.getViewport scale
-					, (error) ->
-						console.log 'ERROR', error
+					, (error) =>
+						@errorCallback?(error)
 
 			getDestinations: () ->
 				@document.then (pdfDocument) ->
@@ -68,8 +68,8 @@ define [
 					pdfDocument.getDestinations()
 				return @destinations.then (all) ->
 					all[dest]
-				, (error) ->
-					console.log 'ERROR', error
+				, (error) =>
+					@errorCallback?(error)
 				# When we upgrade we can switch to using the following direct
 				# code.
 				# @document.then (pdfDocument) ->
@@ -78,11 +78,11 @@ define [
 				# 	console.log 'ERROR', error
 
 			getPageIndex: (ref) ->
-				@document.then (pdfDocument) ->
+				@document.then (pdfDocument) =>
 					pdfDocument.getPageIndex(ref).then (idx) ->
 						idx
-					, (error) ->
-						console.log 'ERROR', error
+					, (error) =>
+						@errorCallback?(error)
 
 			getScale: () ->
 				@scale
@@ -152,7 +152,7 @@ define [
 					@spinner.stop(element.canvas)
 					# @jobs = @jobs - 1
 					# @triggerRenderQueue(0)
-					this.errorCallback?('timeout')
+					@errorCallback?('timeout')
 				, @PAGE_LOAD_TIMEOUT
 
 				@pageLoad[pagenum] = @getPage(pagenum)
@@ -259,11 +259,11 @@ define [
 					page.getTextContent().then (textContent) ->
 						textLayer.setTextContent textContent
 					, (error) ->
-						console.log 'ERROR', error
+						self.errorCallback?(error)
 					page.getAnnotations().then (annotations) ->
 						annotationsLayer.setAnnotations annotations
 					, (error) ->
-						console.log 'ERROR', error
+						self.errorCallback?(error)
 				.catch (error) ->
 					# console.log 'page render failed', pagenum, error
 					$timeout.cancel(timer)

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -145,7 +145,7 @@ define [
 
 				timedOut = false
 				timer = $timeout () =>
-					Raven.captureMessage?('pdfng page load timed out after ' + @PAGE_LOAD_TIMEOUT + 'ms')
+					Raven?.captureMessage?('pdfng page load timed out after ' + @PAGE_LOAD_TIMEOUT + 'ms')
 					# console.log 'page load timed out', pagenum
 					timedOut = true
 					clearTimeout(spinTimer)
@@ -246,7 +246,7 @@ define [
 				timedOut = false
 
 				timer = $timeout () =>
-					Raven.captureMessage?('pdfng page render timed out after ' + @PAGE_RENDER_TIMEOUT + 'ms')
+					Raven?.captureMessage?('pdfng page render timed out after ' + @PAGE_RENDER_TIMEOUT + 'ms')
 					# console.log 'page render timed out', pagenum
 					timedOut = true
 					result.cancel()

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -320,6 +320,8 @@ define [
 					updateLayout()
 
 				scope.$on 'layout:pdf:resize', () ->
+					# FIXME we get this event twice
+					# also we need to start a new layout when we get it
 					console.log 'GOT LAYOUT-PDF-RESIZE EVENT'
 					updateLayout()
 

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -25,7 +25,7 @@ define [
 			# $scope.pages = []
 
 			$scope.document.destroy() if $scope.document?
-			$scope.loadCount = $scope.loadCount? ? $scope.loadCount + 1 : 1
+			$scope.loadCount = if $scope.loadCount? then $scope.loadCount + 1 else 1
 			# TODO need a proper url manipulation library to add to query string
 			$scope.document = new PDFRenderer($scope.pdfSrc + '&pdfng=true' , {
 				scale: 1,

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -38,7 +38,7 @@ define [
 				loadedCallback: () ->
 					$scope.$emit 'loaded'
 				errorCallback: (error) ->
-					Raven.captureMessage?('pdfng error ' + error)
+					Raven?.captureMessage?('pdfng error ' + error)
 					$scope.$emit 'pdf:error', error
 				pageSizeChangeCallback: (pageNum, deltaH) ->
 					$scope.$broadcast 'pdf:page:size-change', pageNum, deltaH

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -58,6 +58,8 @@ define [
 					]
 					# console.log 'resolved q.all, page size is', result
 					$scope.numPages = result.numPages
+				.catch (error) ->
+					$scope.$emit 'pdf:error', 'loading initial document parameters'
 
 		@setScale = (scale, containerHeight, containerWidth) ->
 			$scope.loaded.then () ->
@@ -359,7 +361,7 @@ define [
 				scope.$on 'pdf:error', (event, error) ->
 					return if error == 'cancelled'
 					# check if too many retries or file is missing
-					if scope.loadCount > 3 || error.match(/^Missing PDF/i)
+					if scope.loadCount > 3 || error.match(/^Missing PDF/i) || error.match(/^loading/i)
 						scope.$emit 'pdf:error:display'
 						return
 					ctrl.load()

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -309,7 +309,6 @@ define [
 								scope.loadSuccess = true
 						.catch (error) ->
 							scope.$emit 'pdf:error', error
-							return $q.reject(error)
 
 				elementTimer = null
 				spinnerTimer = null
@@ -373,9 +372,11 @@ define [
 						scope.$emit 'pdf:error:display'
 						return
 					if scope.loadSuccess
-						ctrl.load()
-						# trigger a redraw
-						scope.scale = angular.copy (scope.scale)
+						ctrl.load().then () ->
+							# trigger a redraw
+							scope.scale = angular.copy (scope.scale)
+						.catch (error) ->
+							scope.$emit 'pdf:error:display'
 					else
 						scope.$emit 'pdf:error:display'
 						return
@@ -413,9 +414,11 @@ define [
 					return unless newVal?
 					scope.loadCount = 0; # new pdf, so reset load count
 					scope.loadSuccess = false
-					ctrl.load()
-					# trigger a redraw
-					scope.scale = angular.copy (scope.scale)
+					ctrl.load().then () ->
+						# trigger a redraw
+						scope.scale = angular.copy (scope.scale)
+					.catch (error) ->
+						scope.$emit 'pdf:error', error
 
 				scope.$watch 'scale', (newVal, oldVal) ->
 					# no need to set scale when initialising, done in pdfSrc

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -307,7 +307,7 @@ define [
 						element.innerWidth()
 					]
 					scope.$emit 'flash-controls'
-					#scope.$apply()
+					scope.$apply()
 
 				scope.$on 'layout:main:resize', () ->
 					# console.log 'GOT LAYOUT-MAIN-RESIZE EVENT'
@@ -324,7 +324,7 @@ define [
 						element.innerHeight(),
 						element.innerWidth()
 					]
-					#scope.$apply()
+					scope.$apply()
 
 				scope.$on 'pdf:error', (event, error) ->
 					return if error == 'cancelled'

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -275,24 +275,24 @@ define [
 
 				rescaleTimer = null
 				queueRescale = (scale) ->
-					console.log 'call to queueRescale'
+					# console.log 'call to queueRescale'
 					return if rescaleTimer? or layoutTimer? or elementTimer?
-					console.log 'adding to rescale queue'
+					# console.log 'adding to rescale queue'
 					rescaleTimer = setTimeout () ->
 						doRescale scale
 						rescaleTimer = null
 					, 0
 
 				doRescale = (scale) ->
-					console.log 'doRescale', scale
+					# console.log 'doRescale', scale
 					return unless scale?
 					origposition = angular.copy scope.position
 					# console.log 'origposition', origposition
 					layoutReady.promise.then (parentSize) ->
 						[h, w] = parentSize
-						console.log 'in promise', h, w
+						# console.log 'in promise', h, w
 						ctrl.setScale(scale, h, w).then () ->
-							console.log 'in setscale then', scale, h, w
+							# console.log 'in setscale then', scale, h, w
 							scope.$evalAsync () ->
 								if spinnerTimer
 									clearTimeout spinnerTimer
@@ -305,7 +305,7 @@ define [
 				spinnerTimer = null
 				updateLayout = () ->
 					# if element is zero-sized keep checking until it is ready
-					console.log 'checking element ready', element.height(), element.width()
+					# console.log 'checking element ready', element.height(), element.width()
 					if element.height() == 0 or element.width() == 0
 						return if elementTimer?
 						elementTimer = setTimeout () ->
@@ -317,7 +317,7 @@ define [
 							element.innerHeight(),
 							element.innerWidth()
 						]
-						console.log 'resolving layoutReady with', scope.parentSize
+						# console.log 'resolving layoutReady with', scope.parentSize
 						$timeout () ->
 							if not spinnerTimer?
 								spinnerTimer = setTimeout () ->
@@ -329,31 +329,31 @@ define [
 
 				layoutTimer = null
 				queueLayout = () ->
-					console.log 'call to queue layout'
+					# console.log 'call to queue layout'
 					return if layoutTimer?
-					console.log 'added to queue layoyt'
+					# console.log 'added to queue layoyt'
 					layoutReady = $q.defer()
 					layoutTimer = setTimeout () ->
-						console.log 'calling update layout'
+						# console.log 'calling update layout'
 						updateLayout()
-						console.log 'setting layout timer to null'
+						# console.log 'setting layout timer to null'
 						layoutTimer = null
 					, 0
 
 				queueLayout()
 
-				scope.$on 'layout:pdf:view', (e, args) ->
-					console.log 'pdf view change', element, e, args
-					queueLayout()
+				#scope.$on 'layout:pdf:view', (e, args) ->
+				#	console.log 'pdf view change', element, e, args
+				#	queueLayout()
 
 				scope.$on 'layout:main:resize', () ->
-					console.log 'GOT LAYOUT-MAIN-RESIZE EVENT'
+					# console.log 'GOT LAYOUT-MAIN-RESIZE EVENT'
 					queueLayout()
 
 				scope.$on 'layout:pdf:resize', () ->
 					# FIXME we get this event twice
 					# also we need to start a new layout when we get it
-					console.log 'GOT LAYOUT-PDF-RESIZE EVENT'
+					# console.log 'GOT LAYOUT-PDF-RESIZE EVENT'
 					queueLayout()
 
 				scope.$on 'pdf:error', (event, error) ->
@@ -504,7 +504,7 @@ define [
 						ctrl.setPdfPosition(scope.pages[first.page], position)
 
 				scope.$on '$destroy', () ->
-					console.log 'handle pdfng directive destroy'
+					# console.log 'handle pdfng directive destroy'
 					clearTimeout elementTimer if elementTimer?
 					clearTimeout layoutTimer if layoutTimer?
 					clearTimeout rescaleTimer if rescaleTimer?


### PR DESCRIPTION
Add missing scope.apply's needed to fix up the new pdf viewer when there are no digests running in the background.  

Now queues redraws/relayouts so they only occur once.