### PR TITLE
Email Verification

### DIFF
--- a/app/coffee/Features/ConfirmEmail/ConfirmEmailController.coffee
+++ b/app/coffee/Features/ConfirmEmail/ConfirmEmailController.coffee
@@ -1,0 +1,46 @@
+ConfirmEmailHandler = require("./ConfirmEmailHandler")
+ConfirmEmailTokenHandler = require("./ConfirmEmailTokenHandler")
+RateLimiter = require("../../infrastructure/RateLimiter")
+UserController = require("../User/UserController")
+UserUpdater = require("../User/UserUpdater")
+UserGetter = require("../User/UserGetter")
+logger = require "logger-sharelatex"
+
+module.exports =
+
+	renderCreatePasswordForm: (req, res)->
+		res.render "user/createPassword", 
+			title:"create_password"
+			emailVerificationToken:req.query.emailVerificationToken
+
+	renderUpdateEmail: (req, res)->
+		ConfirmEmailTokenHandler.getEmailFromTokenAndExpire req.query.emailVerificationToken, (err, emails)->
+			if err
+				logger.err err: err, "Error while retrieving the verification token"
+				return res.send 500, {message: "Error"}
+			if !emails?
+				logger.err req.query.emailVerificationToken, "token for registration did not find email"
+				return res.send 500, {message: "Error"}
+			UserGetter.getUser email:emails.oldEmail, (err, user)->
+				if err
+					logger.err err: err, "Error while retrieving user from email"
+					return res.send 500, {message: "Error"}
+				if !user?
+					logger.err emails.oldEmail, "user could not be found for update email"
+					return res.send 500, {message: "Error"}
+				UserUpdater.changeEmailAddress user._id, emails.newEmail, (err)->
+					if err?
+						logger.err err:err, user._id, emails.newEmail, "problem updaing users email address"
+						if err.message == "alread_exists"
+							message = req.i18n.translate("alread_exists")
+						else
+							message = req.i18n.translate("problem_changing_email_address")
+						return res.send 500, {message:message}
+					res.render "general/emailValidate"			
+
+	requestCreatePassword: (req, res, next)->
+		{emailVerificationToken, password} = req.body
+		if !password? or password.length == 0 or !emailVerificationToken? or emailVerificationToken.length == 0
+			return res.send 500
+		ConfirmEmailHandler.createPassword emailVerificationToken?.trim(), password?.trim(), req, res, (req, res, next)->
+      UserController.register req, res, next

--- a/app/coffee/Features/ConfirmEmail/ConfirmEmailHandler.coffee
+++ b/app/coffee/Features/ConfirmEmail/ConfirmEmailHandler.coffee
@@ -1,0 +1,40 @@
+settings = require("settings-sharelatex")
+async = require("async")
+UserGetter = require("../User/UserGetter")
+ConfirmEmailTokenHandler = require("./ConfirmEmailTokenHandler")
+EmailHandler = require("../Email/EmailHandler")
+AuthenticationManager = require("../Authentication/AuthenticationManager")
+UserRegistrationHandler = require("../User/UserRegistrationHandler")
+
+logger = require("logger-sharelatex")
+
+module.exports =
+
+  generateAndEmailVerificationToken:(emails, action, callback = (error, exists) ->)->
+    UserGetter.getUser email:emails.newEmail, (err, user)->
+      if err then return callback(err)
+      if user?
+        logger.err email:emails.newEmail, "User is already register"
+        return callback(null, true)
+      ConfirmEmailTokenHandler.getNewTokenVerificationEmail emails, (err, token)->
+        if err then return callback(err)
+        emailOptions =
+          to : emails.newEmail
+          setEmailVerificationUrl : "#{settings.siteUrl}/user/#{action}?emailVerificationToken=#{token}"
+        EmailHandler.sendEmail "emailVerificationRequested", emailOptions, (error) ->
+          return callback(error) if error?
+          callback null, false
+
+  createPassword: (token, password, req, res,  callback )->
+    ConfirmEmailTokenHandler.getEmailFromTokenAndExpire token, (err, emails)->
+      if err
+        logger.err err: err, "Error while retrieving the verification token"
+        return res.send 500, {message: "Error"}
+      if !emails?
+        logger.err token, "token for registration did not find email"
+        return res.send 500, {message: "Error"}
+      req.body.email = emails.newEmail
+      req.body.password = password
+      callback req, res
+
+

--- a/app/coffee/Features/ConfirmEmail/ConfirmEmailTokenHandler.coffee
+++ b/app/coffee/Features/ConfirmEmail/ConfirmEmailTokenHandler.coffee
@@ -1,0 +1,31 @@
+Settings = require('settings-sharelatex')
+redis = require('redis')
+rclient = redis.createClient(Settings.redis.web.port, Settings.redis.web.host)
+rclient.auth(Settings.redis.web.password)
+crypto = require("crypto")
+logger = require("logger-sharelatex")
+
+ONE_HOUR_IN_S = 60 * 60
+
+buildKey = (token)-> return "email_token:#{token}"
+
+module.exports =
+
+	getNewTokenVerificationEmail: (emails, callback)->
+		logger.log email:emails, "generating token for email verification"
+		token = crypto.randomBytes(32).toString("hex")
+		multi = rclient.multi()
+		multi.hset buildKey(token), "newEmail", emails.newEmail
+		multi.hset buildKey(token), "oldEmail", emails.oldEmail
+		multi.expire buildKey(token), ONE_HOUR_IN_S
+		multi.exec (err)->
+			callback(err, token)
+
+	getEmailFromTokenAndExpire: (token, callback)->
+		logger.log token:token, "getting user email from email token"
+		multi = rclient.multi()
+		multi.hgetall buildKey(token)
+		multi.del buildKey(token)
+		multi.exec (err, results)->
+			callback err, results[0]
+

--- a/app/coffee/Features/Email/EmailBuilder.coffee
+++ b/app/coffee/Features/Email/EmailBuilder.coffee
@@ -73,6 +73,39 @@ If you didn't request a password reset, let us know.
 <p> <a href="<%= siteUrl %>"> ShareLatex.com </a></p>
 '''
 
+
+templates.emailVerificationRequested =	
+	subject:  _.template "Email Verification - ShareLatex.com"
+	layout: NotificationEmailLayout
+	type:"notification"
+	compiledTemplate: _.template '''
+<h1 class="h1">Email Verification</h1>
+<p>
+Thanks for using ShareLatex. In order to confirm your email address please click on the button below.
+<p>
+<center>
+	<div style="width:200px;background-color:#a93629;border:1px solid #e24b3b;border-radius:3px;padding:15px; margin:12.5px;">
+		<div style="padding-right:10px;padding-left:10px">
+			<a href="<%= setEmailVerificationUrl %>" style="text-decoration:none" target="_blank">
+				<span style= "font-size:16px;font-family:Arial;font-weight:bold;color:#fff;white-space:nowrap;display:block; text-align:center">
+		  			Confirm Email
+				</span>
+			</a>
+		</div>
+	</div>
+</center>
+
+If you ignore this message, your email won't be confirmed.
+<p>
+If you didn't request an account, let us know.
+
+</p>
+<p>Thank you</p>
+<p> <a href="<%= siteUrl %>"> ShareLatex.com </a></p>
+'''
+
+
+
 templates.projectSharedWithYou = 
 	subject: _.template "<%= owner.email %> wants to share <%= project.name %> with you"
 	layout: NotificationEmailLayout

--- a/app/coffee/Features/Project/ProjectController.coffee
+++ b/app/coffee/Features/Project/ProjectController.coffee
@@ -139,15 +139,17 @@ module.exports = ProjectController =
 				user = results.user
 				ProjectController._injectProjectOwners projects, (error, projects) ->
 					return next(error) if error?
-
+                    
 					viewModel = {
 						title:'your_projects'
 						priority_title: true
 						projects: projects
 						tags: tags
-						user: user
+						user: user 
 						hasSubscription: results.hasSubscription[0]
+						canCreateProject: SecurityManager.userCanCreateProject(req.session.user)
 					}
+					logger.log viewModel
 
 					if Settings?.algolia?.app_id? and Settings?.algolia?.read_only_api_key?
 						viewModel.showUserDetailsArea = true

--- a/app/coffee/Features/User/UserPagesController.coffee
+++ b/app/coffee/Features/User/UserPagesController.coffee
@@ -21,6 +21,22 @@ module.exports =
 			newTemplateData: newTemplateData
 			new_email:req.query.new_email || ""
 
+	registerPageEmail : (req, res)->
+		sharedProjectData =
+			project_name:req.query.project_name
+			user_first_name:req.query.user_first_name
+
+		newTemplateData = {}
+		if req.session.templateData?
+			newTemplateData.templateName = req.session.templateData.templateName
+
+		res.render 'user/registerEmail',
+			title: 'register'
+			redir: req.query.redir
+			sharedProjectData: sharedProjectData
+			newTemplateData: newTemplateData
+			new_email:req.query.new_email || ""
+
 	loginPage : (req, res)->
 		res.render 'user/login',
 			title: 'login',

--- a/app/coffee/managers/SecurityManager.coffee
+++ b/app/coffee/managers/SecurityManager.coffee
@@ -12,6 +12,26 @@ querystring = require('querystring')
 async = require "async"
 
 module.exports = SecurityManager =
+	userCanCreateProject : (user)->
+		logger.log "SecurityManager.userCanCreateProject"
+		email = user.email
+		suffix = email.split("@")[1]
+		domains = Settings.security.authorizedDomains
+		if domains == "any"
+			return true
+		for d in domains
+			if d == suffix
+				return true
+		return false
+
+	requestCanCreateProject : (req, res, next)->	
+		logger.log "SecurityManager.requestCanCreateProject"
+		if SecurityManager.userCanCreateProject(req.user)
+			next()
+		else
+			res.redirect('/restricted')
+			logger.log "email: #{email} can not create project redirecting to restricted page"
+
 	restricted : (req, res, next)->
 		if req.session.user?
 			res.render 'user/restricted',

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -83,7 +83,7 @@ module.exports = class Router
 		app.get  '/user/:user_id/personal_info', httpAuth, UserInfoController.getPersonalInfo
 
 		app.get  '/project', AuthenticationController.requireLogin(), ProjectController.projectListPage
-		app.post '/project/new', AuthenticationController.requireLogin(), ProjectController.newProject
+		app.post '/project/new', AuthenticationController.requireLogin(), SecurityManager.requestCanCreateProject, ProjectController.newProject
 
 		app.get  '/Project/:Project_id', RateLimiterMiddlewear.rateLimit({
 			endpointName: "open-project"
@@ -111,7 +111,7 @@ module.exports = class Router
 
 		app.del  '/Project/:Project_id', SecurityManager.requestIsOwner, ProjectController.deleteProject
 		app.post '/Project/:Project_id/restore', SecurityManager.requestIsOwner, ProjectController.restoreProject
-		app.post '/Project/:Project_id/clone', SecurityManager.requestCanAccessProject, ProjectController.cloneProject
+		app.post '/Project/:Project_id/clone', SecurityManager.requestCanAccessProject, SecurityManager.requestCanCreateProject, ProjectController.cloneProject
 
 		app.post '/project/:Project_id/rename', SecurityManager.requestIsOwner, ProjectController.renameProject
 

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -32,6 +32,7 @@ StaticPagesRouter = require("./Features/StaticPages/StaticPagesRouter")
 ChatController = require("./Features/Chat/ChatController")
 BlogController = require("./Features/Blog/BlogController")
 WikiController = require("./Features/Wiki/WikiController")
+ConfirmEmailController = require ("./Features/ConfirmEmail/ConfirmEmailController")
 Modules = require "./infrastructure/Modules"
 RateLimiterMiddlewear = require('./Features/Security/RateLimiterMiddlewear')
 
@@ -53,11 +54,21 @@ module.exports = class Router
 		app.get  '/logout', UserController.logout
 		app.get  '/restricted', SecurityManager.restricted
 
-		app.get  '/register', UserPagesController.registerPage
-		app.post '/register', UserController.register
+		if Settings.security.emailVerification
+			app.get  '/register', UserPagesController.registerPageEmail
+			app.post '/register', UserController.registerEmail
+			app.get '/register_email/confirmation', (req, res) -> res.render "general/confirmation"
+			app.get '/update/email/validated', (req, res) -> res.render "general/emailValidate"
+			app.get '/user/update/email', ConfirmEmailController.renderUpdateEmail
+			app.get '/user/password/create', ConfirmEmailController.renderCreatePasswordForm
+			app.post '/user/password/create', ConfirmEmailController.requestCreatePassword
+		else
+			app.get  '/register', UserPagesController.registerPage
+			app.post '/register', UserController.register
 
 		EditorRouter.apply(app, httpAuth)
 		CollaboratorsRouter.apply(app)
+
 		SubscriptionRouter.apply(app)
 		UploadsRouter.apply(app)
 		PasswordResetRouter.apply(app)

--- a/app/views/general/confirmation.jade
+++ b/app/views/general/confirmation.jade
@@ -1,0 +1,13 @@
+extends ../layout
+
+block content
+	.content
+		.container
+			.row
+				.col-md-8.col-md-offset-2.text-center
+					.page-header
+						h2 #{translate("confirmation_email_sent")}
+					p
+						a(href="/")
+							i.fa.fa-arrow-circle-o-left
+							|  #{translate("take_me_home")}

--- a/app/views/general/emailValidate.jade
+++ b/app/views/general/emailValidate.jade
@@ -1,0 +1,13 @@
+extends ../layout
+
+block content
+	.content
+		.container
+			.row
+				.col-md-8.col-md-offset-2.text-center
+					.page-header
+						h2 #{translate("email_changed_successfully")}
+					p
+						a(href="/")
+							i.fa.fa-arrow-circle-o-left
+							|  #{translate("take_me_home")}

--- a/app/views/project/list/project-list.jade
+++ b/app/views/project/list/project-list.jade
@@ -69,24 +69,24 @@
 						li.divider
 						li
 							a(href="#", ng-click="openNewTagModal()", stop-propagation="click") #{translate("create_new_folder")}
-
-				.btn-group(ng-hide="selectedProjects.length != 1").dropdown
-					a.btn.btn-default.dropdown-toggle(
-						href='#',
-						data-toggle="dropdown"
-					) #{translate("more")}
-						span.caret
-					ul.dropdown-menu.dropdown-menu-right(role="menu")
-						li(ng-show="getFirstSelectedProject().accessLevel == 'owner'")
-							a(
-								href='#',
-								ng-click="openRenameProjectModal()"
-							) #{translate("rename")}
-						li
-							a(
-								href='#',
-								ng-click="openCloneProjectModal()"
-							) #{translate("make_copy")}
+				if canCreateProject
+					.btn-group(ng-hide="selectedProjects.length != 1").dropdown
+						a.btn.btn-default.dropdown-toggle(
+							href='#',
+							data-toggle="dropdown"
+						) #{translate("more")}
+							span.caret
+						ul.dropdown-menu.dropdown-menu-right(role="menu")
+							li(ng-show="getFirstSelectedProject().accessLevel == 'owner'")
+								a(
+									href='#',
+									ng-click="openRenameProjectModal()"
+								) #{translate("rename")}
+							li
+								a(
+									href='#',
+									ng-click="openCloneProjectModal()"
+								) #{translate("make_copy")}
 
 			.btn-toolbar(ng-show="filter == 'archived'")
 				.btn-group(ng-hide="selectedProjects.length < 1")

--- a/app/views/project/list/side-bar.jade
+++ b/app/views/project/list/side-bar.jade
@@ -1,33 +1,42 @@
-.dropdown
-	a.btn.btn-primary.dropdown-toggle(
-		href="#",
-		data-toggle="dropdown"
-	)
-		| #{translate("new_project")}
+if canCreateProject
+	.dropdown
+		a.btn.btn-primary.dropdown-toggle(
+			href="#",
+			data-toggle="dropdown"
+		)
+			| #{translate("new_project")}
 
-	ul.dropdown-menu(role="menu")
-		li
-			a(
-				href,
-				ng-click="openCreateProjectModal()"
-			) #{translate("blank_project")}
-		li
-			a(
-				href,
-				ng-click="openCreateProjectModal('example')"
-			) #{translate("example_project")}
-		li
-			a(
-				href,
-				ng-click="openUploadProjectModal()"
-			) #{translate("upload_project")}
-		!{moduleIncludes("newProjectMenu", locals)}
-		if (templates)
-			li.divider
-			li.dropdown-header #{translate("templates")}
-			each item in templates
-				li
-					a.menu-indent(href=item.url) #{translate(item.name)}
+		ul.dropdown-menu(role="menu")
+			li
+				a(
+					href,
+					ng-click="openCreateProjectModal()"
+				) #{translate("blank_project")}
+			li
+				a(
+					href,
+					ng-click="openCreateProjectModal('example')"
+				) #{translate("example_project")}
+			li
+				a(
+					href,
+					ng-click="openUploadProjectModal()"
+				) #{translate("upload_project")}
+			!{moduleIncludes("newProjectMenu", locals)}
+			if (templates)
+				li.divider
+					li.dropdown-header #{translate("templates")}
+				each item in templates
+					li
+						a.menu-indent(href=item.url) #{translate(item.name)}
+
+	.row-spaced(ng-if="projects.length == 0", ng-cloak)
+		.first-project
+			div
+				i.fa.fa-arrow-up.fa-2x
+					div
+						strong #{translate("create_your_first_project")}
+
 
 .row-spaced(ng-if="projects.length > 0", ng-cloak)
 	ul.list-unstyled.folders-menu(
@@ -55,19 +64,12 @@
 						'fa-folder-o': !tag.selected\
 					}"
 				)
-				span.name {{tag.name}} 
+					span.name {{tag.name}} 
 					span.subdued  ({{tag.project_ids.length}})
 		li(ng-cloak)
 			a.tag(href, ng-click="openNewTagModal()")
 				i.fa.fa-fw.fa-plus
 				span.name #{translate("new_folder")}
-
-.row-spaced(ng-if="projects.length == 0", ng-cloak)
-	.first-project
-		div
-			i.fa.fa-arrow-up.fa-2x
-		div
-			strong #{translate("create_your_first_project")}
 
 - if (showUserDetailsArea)
 	.row-spaced#userProfileInformation(ng-if="projects.length > 0", ng-cloak)
@@ -77,8 +79,8 @@
 				.progress
 					.progress-bar.progress-bar-info(ng-style="{'width' : (percentComplete+'%')}")
 
-				p.small #{translate("profile_complete_percentage", {percentval:"{{percentComplete}}"})}
-				
+					p.small #{translate("profile_complete_percentage", {percentval:"{{percentComplete}}"})}
+
 				button#completeUserProfileInformation.btn.btn-info(
 					ng-hide="formVisable",
 					ng-click="openUserProfileModal()"

--- a/app/views/user/createPassword.jade
+++ b/app/views/user/createPassword.jade
@@ -1,0 +1,44 @@
+extends ../layout
+
+block content
+	.content.content-alt
+		.container
+			.row
+				.col-md-6.col-md-offset-3.col-lg-4.col-lg-offset-4
+					.card
+						.page-header
+							h1 #{translate("enter_your_password")}
+						form(
+							async-form="password-create",
+							name="passwordCreateForm"
+							action="/user/password/create",
+							ng-cloak
+						)
+							input(type="hidden", name="_csrf", value=csrfToken)
+							form-messages(for="passwordCreateForm")
+								.alert.alert-success(ng-show="passwordCreateForm.response.success")
+									| #{translate("password_has_been_created")}
+									a(href='/login') #{translate("login_here")}
+
+							.form-group
+								input.form-control(
+									type='password',
+									name='password',
+									placeholder='new password',
+									required,
+									ng-model="password",
+									autofocus
+								)
+								span.small.text-primary(
+									ng-show="passwordCreateForm.password.$invalid && passwordCreateForm.password.$dirty"
+								) #{translate("required")}
+								input(
+									type="hidden",
+									name="emailVerificationToken",
+									value=emailVerificationToken
+								)
+							.actions
+								button.btn.btn-primary(
+									type='submit',
+									ng-disabled="passwordCreateForm.$invalid"
+								) #{translate("create_new_password")}

--- a/app/views/user/registerEmail.jade
+++ b/app/views/user/registerEmail.jade
@@ -1,0 +1,46 @@
+extends ../layout
+
+block content
+	.content.content-alt
+		.container
+			.row
+				.registration_message
+					if sharedProjectData.user_first_name !== undefined
+						h1  #{translate("user_wants_you_to_see_project", {username:sharedProjectData.user_first_name, projectname:sharedProjectData.project_name})}
+						div #{translate("join_sl_to_view_project")}
+					else if newTemplateData.templateName !== undefined
+						h1 #{translate("register_to_edit_template", {templatename:newTemplateData.templateName})}
+
+						div #{translate("already_have_sl_account")}
+							a(href="/login") #{translate("login_here")}
+
+			.row
+				.col-md-6.col-md-offset-3.col-lg-4.col-lg-offset-4
+					.card
+						.page-header
+							h1 #{translate("register")}
+						form(async-form="register", name="registerForm", action="/register", ng-cloak)
+							input(name='_csrf', type='hidden', value=csrfToken)
+							input(name='redir', type='hidden', value=redir)
+							form-messages(for="registerForm")
+							.form-group
+								label(for='email') #{translate("email")}
+								input.form-control(
+									type='email',
+									name='email',
+									placeholder="email@example.com"
+									required,
+									ng-model="email",
+									ng-init="email = #{JSON.stringify(new_email)}",
+									ng-model-options="{ updateOn: 'blur' }",
+									focus="true"
+								)
+								span.small.text-primary(ng-show="registerForm.email.$invalid && registerForm.email.$dirty")
+									| #{translate("must_be_email_address")}
+							.actions
+								button.btn-primary.btn(
+									type='submit'
+									ng-disabled="registerForm.inflight"
+								)
+									span(ng-show="!registerForm.inflight") #{translate("register")}
+									span(ng-show="registerForm.inflight") #{translate("registering")}...

--- a/public/coffee/directives/asyncForm.coffee
+++ b/public/coffee/directives/asyncForm.coffee
@@ -1,7 +1,7 @@
 define [
 	"base"
 ], (App) ->
-	App.directive "asyncForm", ($http) ->
+	App.directive "asyncForm", ($http, $log) ->
 		return {
 			link: (scope, element, attrs) ->
 				formName = attrs.asyncForm
@@ -17,10 +17,10 @@ define [
 						formData[data.name] = data.value
 
 					scope[attrs.name].inflight = true
-
 					$http
 						.post(element.attr('action'), formData)
 						.success (data, status, headers, config) ->
+							$log.info "success"
 							scope[attrs.name].inflight = false
 							response.success = true
 							response.error = false

--- a/test/UnitTests/coffee/Project/ProjectControllerTests.coffee
+++ b/test/UnitTests/coffee/Project/ProjectControllerTests.coffee
@@ -40,6 +40,7 @@ describe "ProjectController", ->
 			findById: sinon.stub()
 		@SecurityManager =
 			userCanAccessProject:sinon.stub()
+			userCanCreateProject:sinon.stub()
 		@EditorController = 
 			renameProject:sinon.stub()
 		@ProjectController = SandboxedModule.require modulePath, requires:
@@ -205,6 +206,7 @@ describe "ProjectController", ->
 			@LimitationsManager.userHasSubscriptionOrIsGroupMember.callsArgWith(1, null, false)
 			@TagsHandler.getAllTags.callsArgWith(1, null, @tags, {})
 			@ProjectModel.findAllUsersProjects.callsArgWith(2, null, @projects, @collabertions, @readOnly)
+			@SecurityManager.userCanCreateProject.returns "boolean"
 
 		it "should render the project/list page", (done)->
 			@res.render = (pageName, opts)=>
@@ -227,6 +229,12 @@ describe "ProjectController", ->
 		it "should send the user", (done)->
 			@res.render = (pageName, opts)=>
 				opts.user.should.deep.equal @user
+				done()
+			@ProjectController.projectListPage @req, @res
+
+		it "should send the canCreateProject flag", (done)->
+			@res.render = (pageName, opts)=>
+				opts.canCreateProject.should.equal "boolean"
 				done()
 			@ProjectController.projectListPage @req, @res
 


### PR DESCRIPTION
This PR is a first step to email verification. The missing feature has been referenced in #136 and #148.
In my use case, users are split into two  categories : internal and external. 
internal can create/manage projects, external can't create/copy project. This behaviour is handled by the first commit. ```security.authorizedDomains``` in the config file is an array of email domains corresponding to internal users.
Moreover in my use case I want email verification (1) at creation time (2) at modification time. This is adressed by the second commit. The email verification can be disabled in the settings (```security.emailVerification```)

Those commits are subject to changes, I only want to share this piece of code a start a discussion here about the feature.

