### PR TITLE
Support cached pdfs with build parameter

### DIFF
--- a/app/coffee/Features/Compile/ClsiManager.coffee
+++ b/app/coffee/Features/Compile/ClsiManager.coffee
@@ -54,6 +54,7 @@ module.exports = ClsiManager =
 			outputFiles.push
 				path: url.parse(file.url).path.replace("/project/#{project_id}/output/", "")
 				type: file.type
+				build: file.build
 		return outputFiles
 
 	VALID_COMPILERS: ["pdflatex", "latex", "xelatex", "lualatex"]

--- a/app/coffee/Features/Compile/CompileController.coffee
+++ b/app/coffee/Features/Compile/CompileController.coffee
@@ -85,15 +85,20 @@ module.exports = CompileController =
 		url = "#{compilerUrl}#{url}"
 		logger.log url: url, "proxying to CLSI"
 		oneMinute = 60 * 1000
-		# pass through If-* and Range headers for byte serving pdfs
-		# do not send any others, potential proxying loop if Host: is passed!
+		# the base request
+		options = { url: url, method: req.method,	timeout: oneMinute }
+		# if we have a build parameter, pass it through to the clsi
+		if req.query?.build?
+			options.qs = {}
+			options.qs.build = req.query.build
+		# if we are byte serving pdfs, pass through If-* and Range headers
+		# do not send any others, there's a proxying loop if Host: is passed!
 		if req.query?.pdfng
 			newHeaders = {}
 			for h, v of req.headers
 				newHeaders[h] = req.headers[h] if h.match /^(If-|Range)/i
-			proxy = request(url: url, method: req.method, timeout: oneMinute, headers: newHeaders)
-		else
-			proxy = request(url: url, method: req.method, timeout: oneMinute)
+			options.headers = newHeaders
+		proxy = request(options)
 		proxy.pipe(res)
 		proxy.on "error", (error) ->
 			logger.warn err: error, url: url, "CLSI proxy error"

--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -41,12 +41,17 @@ define [
 				$scope.pdf.failure = true
 				fetchLogs()
 			else if response.status == "success"
+				$scope.pdf.url = "/project/#{$scope.project_id}/output/output.pdf?cache_bust=#{Date.now()}"
 				if response.compileGroup?
 					$scope.pdf.compileGroup = response.compileGroup
-					$scope.pdf.url = "/project/#{$scope.project_id}/output/output.pdf?cache_bust=#{Date.now()}" +
-						"&compileGroup=#{$scope.pdf.compileGroup}"
-				else
-					$scope.pdf.url = "/project/#{$scope.project_id}/output/output.pdf?cache_bust=#{Date.now()}"
+					$scope.pdf.url = $scope.pdf.url + "&compileGroup=#{$scope.pdf.compileGroup}"
+				fileByPath = {}
+				for file in response.outputFiles
+					fileByPath[file.path] = file
+				if fileByPath['output.pdf']?.build?
+					build = fileByPath['output.pdf'].build
+					$scope.pdf.url = $scope.pdf.url + "&build=#{build}"
+
 				fetchLogs()
 
 			IGNORE_FILES = ["output.fls", "output.fdb_latexmk"]

--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -165,8 +165,7 @@ define [
 			$scope.pdf.showRawLog = !$scope.pdf.showRawLog
 
 		$scope.openOutputFile = (file) ->
-			qs = if file.build? then "?build=#{file.build}" else ""
-			window.open("/project/#{$scope.project_id}/output/#{file.path}#{qs}")
+			window.open("/project/#{$scope.project_id}/output/#{file.path}")
 
 		$scope.openClearCacheModal = () ->
 			modalInstance = $modal.open(

--- a/test/UnitTests/coffee/Compile/ClsiManagerTests.coffee
+++ b/test/UnitTests/coffee/Compile/ClsiManagerTests.coffee
@@ -36,9 +36,11 @@ describe "ClsiManager", ->
 						outputFiles: [{
 							url: "#{@settings.apis.clsi.url}/project/#{@project_id}/output/output.pdf"
 							type: "pdf"
+							build: 1234
 						},{
 							url: "#{@settings.apis.clsi.url}/project/#{@project_id}/output/output.log"
 							type: "log"
+							build: 1234
 						}]
 				})
 				@ClsiManager.sendRequest @project_id, {compileGroup:"standard"}, @callback
@@ -57,9 +59,11 @@ describe "ClsiManager", ->
 				outputFiles = [{
 					path: "output.pdf"
 					type: "pdf"
+					build: 1234
 				},{
 					path: "output.log"
 					type: "log"
+					build: 1234
 				}]
 				@callback.calledWith(null, @status, outputFiles).should.equal true
 

--- a/test/UnitTests/coffee/Compile/CompileControllerTests.coffee
+++ b/test/UnitTests/coffee/Compile/CompileControllerTests.coffee
@@ -231,6 +231,21 @@ describe "CompileController", ->
 						)
 						.should.equal true
 
+			describe "user with build parameter via query string", ->
+				beforeEach ->
+					@CompileManager.getProjectCompileLimits = sinon.stub().callsArgWith(1, null, {compileGroup: "standard"})
+					@req.query = {build: 1234}
+					@CompileController.proxyToClsi(@project_id, @url = "/test", @req, @res, @next)
+
+				it "should proxy to the standard url with the build parameter", ()->
+					@request
+						.calledWith(
+							method: @req.method
+							qs: {build: 1234}
+							url: "#{@settings.apis.clsi.url}#{@url}",
+							timeout: 60 * 1000
+						)
+						.should.equal true
 
 		describe "new pdf viewer", ->
 			beforeEach ->


### PR DESCRIPTION
Use the build identifier provided by the CLSI to request output files from a specific build.

Should prevent output files from changing while they are being downloaded.