### PR TITLE
Update word regex for spellcheck

### DIFF
--- a/public/coffee/ide/editor/directives/aceEditor/spell-check/SpellCheckManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/spell-check/SpellCheckManager.coffee
@@ -171,7 +171,7 @@ define [
 			positions = []
 			for line, row in lines
 				if !linesToProcess? or linesToProcess[row]
-					wordRegex = /\\?['a-zA-Z\u00C0-\u00FF]+/g
+					wordRegex = /\\?['a-zA-Z\u00C0-\u017F]+/g
 					while (result = wordRegex.exec(line))
 						word = result[0]
 						if word[0] == "'"


### PR DESCRIPTION
Adds [Latin Extended-A](https://en.wikipedia.org/wiki/Latin_Extended-A) characters to word regex to prevent splitting words half way through on characters like ąęćółżźńś.

Should close issue #58.