### PR TITLE
Suggested API endpoint for JSON-response with projects and tags

### DIFF
--- a/app/coffee/Features/Project/ProjectApiController.coffee
+++ b/app/coffee/Features/Project/ProjectApiController.coffee
@@ -1,6 +1,9 @@
 ProjectDetailsHandler = require("./ProjectDetailsHandler")
 logger = require("logger-sharelatex")
-
+async = require("async")
+Project = require('../../models/Project').Project
+TagsHandler = require("../Tags/TagsHandler")
+ProjectController = require("./ProjectController")
 
 module.exports = 
 
@@ -13,3 +16,22 @@ module.exports =
 			req.session.destroy()
 			res.json(projDetails)
 
+	getProjectList : (req, res)->
+		user_id = req.user._id
+		async.parallel {
+			tags: (cb)->
+				TagsHandler.getAllTags user_id, cb
+			projects: (cb)->
+				Project.findAllUsersProjects user_id, 'name lastUpdated publicAccesLevel archived owner_ref', cb
+			}, (err, results)->
+				if err?
+					logger.err err:err, "error getting data for project list"
+					return res.send 500
+				logger.log results:results, user_id:user_id, "building project list"
+				tags = results.tags[0]
+				projects = ProjectController._buildProjectList results.projects[0], results.projects[1], results.projects[2]
+				logger.log projects: projects, "final project list"
+				res.json({
+					projects: projects 
+					tags: tags
+				})

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -15,6 +15,7 @@ metrics = require('./infrastructure/Metrics')
 ReferalController = require('./Features/Referal/ReferalController')
 ReferalMiddleware = require('./Features/Referal/ReferalMiddleware')
 AuthenticationController = require('./Features/Authentication/AuthenticationController')
+AuthenticationManager = require ("./Features/Authentication/AuthenticationManager")
 TagsController = require("./Features/Tags/TagsController")
 CollaboratorsRouter = require('./Features/Collaborators/CollaboratorsRouter')
 UserInfoController = require('./Features/User/UserInfoController')
@@ -154,6 +155,13 @@ module.exports = class Router
 		app.post "/project/:Project_id/messages", SecurityManager.requestCanAccessProject, ChatController.sendMessage
 		
 		app.get  /learn(\/.*)?/, WikiController.getPage
+		
+		#API
+		app.get '/api/project', AuthenticationManager.authenticateApi, ProjectApiController.getProjectList
+		app.post '/api/project/:Project_id/compile', AuthenticationManager.authenticateApi, SecurityManager.requestCanAccessProject, CompileController.compile
+		app.ignoreCsrf('post', '/api/project/:Project_id/compile')
+		app.get '/api/project/:Project_id/output/output.pdf', AuthenticationManager.authenticateApi, SecurityManager.requestCanAccessProject, CompileController.downloadPdf
+
 
 		#Admin Stuff
 		app.get  '/admin', SecurityManager.requestIsAdmin, AdminController.index

--- a/test/UnitTests/coffee/Project/ProjectApiControllerTests.coffee
+++ b/test/UnitTests/coffee/Project/ProjectApiControllerTests.coffee
@@ -9,21 +9,31 @@ describe 'Project api controller', ->
 	beforeEach ->
 		@ProjectDetailsHandler = 
 			getDetails : sinon.stub()
+		@TagsHandler =
+			getAllTags: sinon.stub()
+		@ProjectModel =
+			findAllUsersProjects: sinon.stub()
+		@ProjectController = 
+			_buildProjectList: sinon.stub()
 		@controller = SandboxedModule.require modulePath, requires:
 			"./ProjectDetailsHandler":@ProjectDetailsHandler
+			"../Tags/TagsHandler":@TagsHandler
+			"../../models/Project": Project:@ProjectModel
+			"./ProjectController": @ProjectController
 			'logger-sharelatex':
 				log:->
-		@project_id = "321l3j1kjkjl"
-		@req = 
-			params: 
-				project_id:@project_id
-			session:
-				destroy:sinon.stub()
 		@res = {}
-		@projDetails = {name:"something"}
-
 
 	describe "getProjectDetails", ->
+	
+		beforeEach ->
+			@project_id = "321l3j1kjkjl"
+			@req = 
+				params: 
+					project_id:@project_id
+				session:
+					destroy:sinon.stub()
+			@projDetails = {name:"something"}
 
 		it "should ask the project details handler for proj details", (done)->
 			@ProjectDetailsHandler.getDetails.callsArgWith(1, null, @projDetails)
@@ -32,7 +42,6 @@ describe 'Project api controller', ->
 				data.should.deep.equal @projDetails
 				done()
 			@controller.getProjectDetails @req, @res
-
 
 		it "should send a 500 if there is an error", (done)->
 			@ProjectDetailsHandler.getDetails.callsArgWith(1, "error")
@@ -47,3 +56,37 @@ describe 'Project api controller', ->
 				@req.session.destroy.called.should.equal true
 				done()
 			@controller.getProjectDetails @req, @res
+			
+	describe "getProjectList", ->
+	
+		beforeEach ->
+			@req = 
+				params: 
+					[]
+				session:
+					destroy:sinon.stub()
+				user:
+					_id:null
+					
+			@tags = [{name:1, project_ids:["1","2","3"]}, {name:2, project_ids:["a","1"]}, {name:3, project_ids:["a", "b", "c", "d"]}]
+			@projects = [{lastUpdated:1, _id:1, owner_ref: "user-1"}, {lastUpdated:2, _id:2, owner_ref: "user-2"}]
+			@collaborations = [{lastUpdated:5, _id:5, owner_ref: "user-1"}]
+			@readOnly = [{lastUpdated:3, _id:3, owner_ref: "user-1"}]
+			@allProjects = @projects.concat @collaborations.concat @readOnly
+
+			@TagsHandler.getAllTags.callsArgWith(1, null, @tags, {})
+			@ProjectModel.findAllUsersProjects.callsArgWith(2, null, @projects, @collaborations, @readOnly)
+	
+		it "should send the tags", (done)->
+			@res.json = (data)=>
+				data.tags.length.should.equal @tags.length
+				done()
+			@controller.getProjectList @req, @res
+
+		it "should send the projects", (done)->
+			@ProjectController._buildProjectList.returns(@allProjects)
+			@res.json = (data)=>
+				data.projects.length.should.equal (@projects.length + @collaborations.length + @readOnly.length)
+				done()
+			@controller.getProjectList @req, @res
+			


### PR DESCRIPTION
Suggested API endpoints for receiving projects and tags. This pattern can form basis for other endpoints as well.

These endpoints uses the BasicAuth pattern for authentication, see app/coffee/Features/Authentication/AuthenticationManager.coffee.

We're of course willing to change the suggested solution if requested.
