### PR TITLE
Un-fade editor when changing theme

### DIFF
--- a/public/coffee/ide.coffee
+++ b/public/coffee/ide.coffee
@@ -100,7 +100,7 @@ define [
 		]
 		$scope.darkTheme = false
 		$scope.$watch "settings.theme", (theme) ->
-			$("#left-menu-mask").hide(100).delay(1000).show(100);
+			$("#left-menu-mask").fadeIn(100).delay(1000).fadeOut(100);
 			if theme in DARK_THEMES
 				$scope.darkTheme = true
 			else

--- a/public/coffee/ide.coffee
+++ b/public/coffee/ide.coffee
@@ -100,6 +100,7 @@ define [
 		]
 		$scope.darkTheme = false
 		$scope.$watch "settings.theme", (theme) ->
+			$("#left-menu-mask").hide(100).delay(1000).show(100);
 			if theme in DARK_THEMES
 				$scope.darkTheme = true
 			else


### PR DESCRIPTION
Fixes sharelatex/sharelatex#232

This hides the fade for a second and then shows it again. That should be enough to see if you like the color scheme.