### PR TITLE
Public registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,6 @@ public/minjs/
 public/js/main.js
 Gemfile.lock
 
-# Ide generated files
-.kdev4/*
-*.kdev4
 *.swp
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ public/minjs/
 public/js/main.js
 Gemfile.lock
 
+# Ide generated files
+.kdev4/*
+*.kdev4
 *.swp
 .DS_Store
 

--- a/app/coffee/Features/Authentication/AuthenticationController.coffee
+++ b/app/coffee/Features/Authentication/AuthenticationController.coffee
@@ -27,7 +27,7 @@ module.exports = AuthenticationController =
 					if user.confirmed
 						LoginRateLimiter.recordSuccessfulLogin email
 						AuthenticationController._recordSuccessfulLogin user._id
-						AuthenticationController._establishUserSession req, user, (error) ->
+						AuthenticationController.establishUserSession req, user, (error) ->
 							return next(error) if error?
 							logger.log email: email, user_id: user._id.toString(), "successful log in"
 							res.send redir: redir

--- a/app/coffee/Features/Authentication/AuthenticationController.coffee
+++ b/app/coffee/Features/Authentication/AuthenticationController.coffee
@@ -24,13 +24,15 @@ module.exports = AuthenticationController =
 			AuthenticationManager.authenticate email: email, password, (error, user) ->
 				return next(error) if error?
 				if user?
-					LoginRateLimiter.recordSuccessfulLogin email
-					AuthenticationController._recordSuccessfulLogin user._id
-					AuthenticationController.establishUserSession req, user, (error) ->
-						return next(error) if error?
-						req.session.justLoggedIn = true
-						logger.log email: email, user_id: user._id.toString(), "successful log in"
-						res.send redir: redir
+					if user.confirmed
+						LoginRateLimiter.recordSuccessfulLogin email
+						AuthenticationController._recordSuccessfulLogin user._id
+						AuthenticationController._establishUserSession req, user, (error) ->
+							return next(error) if error?
+							logger.log email: email, user_id: user._id.toString(), "successful log in"
+							res.send redir: redir
+					else
+						res.send redir: '/confirm'
 				else
 					AuthenticationController._recordFailedLogin()
 					logger.log email: email, "failed log in"
@@ -50,6 +52,9 @@ module.exports = AuthenticationController =
 			callback null, req.session.user._id.toString()
 		else
 			callback null, null
+
+	getUserFromAuthToken: (auth_token, callback = (error,user)->) ->
+		UserGetter.getUser { auth_token: auth_token }, callback
 
 	getLoggedInUser: (req, options = {allow_auth_token: false}, callback = (error, user) ->) ->
 		if typeof(options) == "function"
@@ -78,7 +83,7 @@ module.exports = AuthenticationController =
 					return next()
 			else
 				if !req.session.user?
-					AuthenticationController._redirectToLoginOrRegisterPage(req, res) 
+					AuthenticationController._redirectToLoginOrRegisterPage(req, res)
 				else
 					req.user = req.session.user
 					return next()
@@ -109,9 +114,9 @@ module.exports = AuthenticationController =
 
 	_redirectToLoginOrRegisterPage: (req, res)->
 		if req.query.zipUrl? or req.query.project_name?
-			return AuthenticationController._redirectToRegisterPage(req, res) 
+			return AuthenticationController._redirectToRegisterPage(req, res)
 		else
-			AuthenticationController._redirectToLoginPage(req, res) 
+			AuthenticationController._redirectToLoginPage(req, res)
 
 
 	_redirectToLoginPage: (req, res) ->

--- a/app/coffee/Features/Authentication/AuthenticationController.coffee
+++ b/app/coffee/Features/Authentication/AuthenticationController.coffee
@@ -83,7 +83,7 @@ module.exports = AuthenticationController =
 					return next()
 			else
 				if !req.session.user?
-					AuthenticationController._redirectToLoginOrRegisterPage(req, res)
+					AuthenticationController._redirectToLoginOrRegisterPage(req, res) 
 				else
 					req.user = req.session.user
 					return next()
@@ -114,9 +114,9 @@ module.exports = AuthenticationController =
 
 	_redirectToLoginOrRegisterPage: (req, res)->
 		if req.query.zipUrl? or req.query.project_name?
-			return AuthenticationController._redirectToRegisterPage(req, res)
+			return AuthenticationController._redirectToRegisterPage(req, res) 
 		else
-			AuthenticationController._redirectToLoginPage(req, res)
+			AuthenticationController._redirectToLoginPage(req, res) 
 
 
 	_redirectToLoginPage: (req, res) ->

--- a/app/coffee/Features/Authentication/AuthenticationManager.coffee
+++ b/app/coffee/Features/Authentication/AuthenticationManager.coffee
@@ -36,6 +36,17 @@ module.exports = AuthenticationManager =
 					$unset: password: true
 				}, callback)
 
+	clearAuthToken: (user_id, callback = (error)->) ->
+		db.users.findOne { _id: ObjectId(user_id.toString()) }, { auth_token : true }, (error, user) =>
+			return callback(error) if error?
+			return callback(new Error("user could not be found: #{user_id}")) if !user?
+			if user.auth_token?
+				db.users.update { _id: ObjectId(user_id.toString()) }, {$set: auth_token : null }, (error) ->
+				    return callback(error) if error?
+				    callback null
+			else
+				callback null
+
 	getAuthToken: (user_id, callback = (error, auth_token) ->) ->
 		db.users.findOne { _id: ObjectId(user_id.toString()) }, { auth_token : true }, (error, user) =>
 			return callback(error) if error?

--- a/app/coffee/Features/Email/EmailBuilder.coffee
+++ b/app/coffee/Features/Email/EmailBuilder.coffee
@@ -117,10 +117,7 @@ module.exports =
 	templates: templates
 
 	buildEmail: (templateName, opts)->
-		if settings.requireRegistrationConfirmation and templateName == "welcome"
-			template = templates["welcome_confirm"]
-		else
-			template = templates[templateName]
+		template = templates[templateName]
 		opts.siteUrl = settings.siteUrl
 		opts.body = template.compiledTemplate(opts)
 		return {

--- a/app/coffee/Features/Email/EmailBuilder.coffee
+++ b/app/coffee/Features/Email/EmailBuilder.coffee
@@ -20,6 +20,31 @@ templates.registered =
 <p>If you have any questions or problems, please contact <a href="mailto:#{settings.adminEmail}">#{settings.adminEmail}</a>.</p>
 """
 
+templates.welcome_confirm =
+	subject:  _.template "Welcome to ShareLaTeX"
+	layout: PersonalEmailLayout
+	type:"lifecycle"
+	compiledTemplate: _.template '''
+Hi <%= first_name %>, thanks for signing up to ShareLaTeX.
+<p>
+
+Please use the following <a href="<%= siteUrl %>/confirm?auth_token=<%= auth_token %>">link</a> to confirm your registration.
+Alternatively, you can copy and paste the following confirmation token
+<pre>
+<%= auth_token %>
+</pre>
+into the form located at <a href="<%= siteUrl %>/confirm">http://<%=siteUrl %>/confirm</a>.
+
+<p>
+I’m the co-founder of ShareLaTeX and I love talking to our users about our service. Please feel free to get in touch by replying to this email and I will get back to you within a day.
+
+<p>
+
+Regards, <br>
+Henry <br>
+ShareLaTeX Co-founder
+'''
+
 templates.canceledSubscription = 
 	subject:  _.template "ShareLaTeX thoughts"
 	layout: PersonalEmailLayout
@@ -92,7 +117,10 @@ module.exports =
 	templates: templates
 
 	buildEmail: (templateName, opts)->
-		template = templates[templateName]
+		if settings.requireRegistrationConfirmation and templateName == "welcome"
+			template = templates["welcome_confirm"]
+		else
+			template = templates[templateName]
 		opts.siteUrl = settings.siteUrl
 		opts.body = template.compiledTemplate(opts)
 		return {

--- a/app/coffee/Features/Email/EmailBuilder.coffee
+++ b/app/coffee/Features/Email/EmailBuilder.coffee
@@ -6,7 +6,7 @@ settings = require("settings-sharelatex")
 
 templates = {}
 
-templates.registered = 
+templates.registered =	
 	subject:  _.template "Activate your #{settings.appName} Account"
 	layout: PersonalEmailLayout
 	type: "notification"

--- a/app/coffee/Features/Email/EmailBuilder.coffee
+++ b/app/coffee/Features/Email/EmailBuilder.coffee
@@ -6,7 +6,7 @@ settings = require("settings-sharelatex")
 
 templates = {}
 
-templates.registered =
+templates.registered = 
 	subject:  _.template "Activate your #{settings.appName} Account"
 	layout: PersonalEmailLayout
 	type: "notification"
@@ -62,7 +62,7 @@ ShareLaTeX Co-founder
 </p>
 '''
 
-templates.passwordResetRequested =
+templates.passwordResetRequested =	
 	subject:  _.template "Password Reset - #{settings.appName}"
 	layout: NotificationEmailLayout
 	type:"notification"
@@ -92,7 +92,7 @@ If you didn't request a password reset, let us know.
 <p> <a href="<%= siteUrl %>">#{settings.appName}</a></p>
 """
 
-templates.projectSharedWithYou =
+templates.projectSharedWithYou = 
 	subject: _.template "<%= owner.email %> wants to share <%= project.name %> with you"
 	layout: NotificationEmailLayout
 	type:"notification"

--- a/app/coffee/Features/Email/EmailBuilder.coffee
+++ b/app/coffee/Features/Email/EmailBuilder.coffee
@@ -6,7 +6,7 @@ settings = require("settings-sharelatex")
 
 templates = {}
 
-templates.registered =	
+templates.registered =
 	subject:  _.template "Activate your #{settings.appName} Account"
 	layout: PersonalEmailLayout
 	type: "notification"
@@ -45,7 +45,7 @@ Henry <br>
 ShareLaTeX Co-founder
 '''
 
-templates.canceledSubscription = 
+templates.canceledSubscription =
 	subject:  _.template "ShareLaTeX thoughts"
 	layout: PersonalEmailLayout
 	type:"lifecycle"
@@ -62,7 +62,7 @@ ShareLaTeX Co-founder
 </p>
 '''
 
-templates.passwordResetRequested =	
+templates.passwordResetRequested =
 	subject:  _.template "Password Reset - #{settings.appName}"
 	layout: NotificationEmailLayout
 	type:"notification"
@@ -92,7 +92,7 @@ If you didn't request a password reset, let us know.
 <p> <a href="<%= siteUrl %>">#{settings.appName}</a></p>
 """
 
-templates.projectSharedWithYou = 
+templates.projectSharedWithYou =
 	subject: _.template "<%= owner.email %> wants to share <%= project.name %> with you"
 	layout: NotificationEmailLayout
 	type:"notification"
@@ -125,4 +125,3 @@ module.exports =
 			html: template.layout(opts)
 			type:template.type
 		}
-

--- a/app/coffee/Features/User/UserController.coffee
+++ b/app/coffee/Features/User/UserController.coffee
@@ -109,7 +109,7 @@ module.exports = UserController =
 					to: user.email
 					setNewPasswordUrl: setNewPasswordUrl
 				}, () ->
-						
+				
 				res.json {
 					email: user.email
 					setNewPasswordUrl: setNewPasswordUrl

--- a/app/coffee/Features/User/UserController.coffee
+++ b/app/coffee/Features/User/UserController.coffee
@@ -109,7 +109,7 @@ module.exports = UserController =
 					to: user.email
 					setNewPasswordUrl: setNewPasswordUrl
 				}, () ->
-								
+						
 				res.json {
 					email: user.email
 					setNewPasswordUrl: setNewPasswordUrl

--- a/app/coffee/Features/User/UserController.coffee
+++ b/app/coffee/Features/User/UserController.coffee
@@ -82,7 +82,6 @@ module.exports = UserController =
 				logger.err err: err, 'error destroying session'
 			res.redirect '/login'
 
-
 	register : (req, res, next = (error) ->)->
 		email = req.body.email
 		if !email? or email == ""
@@ -96,21 +95,21 @@ module.exports = UserController =
 		}, (err, user)->
 			if err? and err?.message != "EmailAlreadyRegistered"
 				return next(err)
-
+			
 			if err?.message == "EmailAlreadyRegistered"
 				logger.log {email}, "user already exists, resending welcome email"
 
 			ONE_WEEK = 7 * 24 * 60 * 60 # seconds
 			PasswordResetTokenHandler.getNewToken user._id, { expiresIn: ONE_WEEK }, (err, token)->
 				return next(err) if err?
-
+				
 				setNewPasswordUrl = "#{settings.siteUrl}/user/password/set?passwordResetToken=#{token}&email=#{encodeURIComponent(email)}"
 
 				EmailHandler.sendEmail "registered", {
 					to: user.email
 					setNewPasswordUrl: setNewPasswordUrl
 				}, () ->
-
+								
 				res.json {
 					email: user.email
 					setNewPasswordUrl: setNewPasswordUrl

--- a/app/coffee/Features/User/UserCreator.coffee
+++ b/app/coffee/Features/User/UserCreator.coffee
@@ -15,6 +15,7 @@ module.exports =
 		user = new User()
 		user.email = opts.email
 		user.holdingAccount = opts.holdingAccount
+		user.confirmed = opts.confirmed
 
 		username = opts.email.match(/^[^@]*/)
 		if username?

--- a/app/coffee/Features/User/UserPagesController.coffee
+++ b/app/coffee/Features/User/UserPagesController.coffee
@@ -18,7 +18,7 @@ module.exports =
 		res.render 'user/register',
 			title: 'register'
 			redir: req.query.redir
-			allowPublicRegistration: settings.allowPublicRegistration
+			allowPublicRegistration: Settings.allowPublicRegistration
 			restrict_domain: Settings.signupDomain?
 			domain: Settings.signupDomain
 			example_email: if Settings.signupDomain? then 'example@' + Settings.signupDomain else 'email@exmaple.com'

--- a/app/coffee/Features/User/UserPagesController.coffee
+++ b/app/coffee/Features/User/UserPagesController.coffee
@@ -1,11 +1,12 @@
 UserLocator = require("./UserLocator")
+UserController = require("./UserController")
 logger = require("logger-sharelatex")
 Settings = require("settings-sharelatex")
 fs = require('fs')
 
 module.exports =
 
-	registerPage : (req, res)->
+	publicRegisterPage : (req, res)->
 		sharedProjectData =
 			project_name:req.query.project_name
 			user_first_name:req.query.user_first_name
@@ -17,9 +18,27 @@ module.exports =
 		res.render 'user/register',
 			title: 'register'
 			redir: req.query.redir
+			allowPublicRegistration: settings.allowPublicRegistration
+			restrict_domain: Settings.signupDomain?
+			domain: Settings.signupDomain
+			example_email: if Settings.signupDomain? then 'example@' + Settings.signupDomain else 'email@exmaple.com'
 			sharedProjectData: sharedProjectData
 			newTemplateData: newTemplateData
 			new_email:req.query.new_email || ""
+
+	confirmRegistrationPage : (req, res)->
+		if req.query.auth_token?
+			req.body = req.query
+			UserController.confirmRegistration req, res, ((error) ->
+				res.render 'user/confirm',
+					title: 'confirm'
+					error: error
+					redir: req.query.redir
+			), true
+		else
+			res.render 'user/confirm',
+				title: 'confirm'
+				redir: req.query.redir
 
 	loginPage : (req, res)->
 		res.render 'user/login',

--- a/app/coffee/Features/User/UserRegistrationHandler.coffee
+++ b/app/coffee/Features/User/UserRegistrationHandler.coffee
@@ -1,4 +1,5 @@
 sanitize = require('sanitizer')
+Settings = require('settings-sharelatex')
 User = require("../../models/User").User
 UserCreator = require("./UserCreator")
 AuthenticationManager = require("../Authentication/AuthenticationManager")
@@ -22,24 +23,35 @@ module.exports =
 		email = sanitize.escape(body.email).trim().toLowerCase()
 		password = body.password
 		username = email.match(/^[^@]*/)
+		domain = email.match(/[^@]*$/)
+		domain = domain[0] if domain?
 		if @hasZeroLengths([password, email])
-			return false
+			return "Password/email cannot be empty"
 		else if !@validateEmail(email)
-			return false
+			return "Invalid email"
+		else if Settings.signupDomain? and Settings.signupDomain != domain
+			return "Invalid domain. Only emails ending with @"+Settings.signupDomain+" accepted."
 		else
-			return true
+			return "OK"
 
 	_createNewUserIfRequired: (user, userDetails, callback)->
 		if !user?
-			UserCreator.createNewUser {holdingAccount:false, email:userDetails.email}, callback
+			UserCreator.createNewUser {holdingAccount:false, email:userDetails.email, confirmed:userDetails.confirmed}, (error,user) ->
+				if user? and Settings.requireRegistrationConfirmation
+					AuthenticationManager.getAuthToken user._id, (error, auth_token)->
+						if !error?
+							user.auth_token = auth_token
+						callback error, user
+				else
+					callback error, user
 		else
 			callback null, user
 
 	registerNewUser: (userDetails, callback)->
 		self = @
-		requestIsValid = @_registrationRequestIsValid userDetails
-		if !requestIsValid
-			return callback(new Error("request is not valid"))
+		validationResult = @_registrationRequestIsValid userDetails
+		if validationResult != "OK"
+			return callback(new Error(validationResult))
 		userDetails.email = userDetails.email?.trim()?.toLowerCase()
 		User.findOne email:userDetails.email, (err, user)->
 			if err?
@@ -52,13 +64,13 @@ module.exports =
 				async.series [
 					(cb)-> User.update {_id: user._id}, {"$set":{holdingAccount:false}}, cb
 					(cb)-> AuthenticationManager.setUserPassword user._id, userDetails.password, cb
+					(cb)-> NewsLetterManager.subscribe user, cb
 					(cb)->
-						NewsLetterManager.subscribe user, ->
-						cb() #this can be slow, just fire it off
+						emailOpts =
+							first_name:user.first_name
+							to: user.email
+							auth_token:user.auth_token
+						EmailHandler.sendEmail "welcome", emailOpts, cb
 				], (err)->
 					logger.log user: user, "registered"
 					callback(err, user)
-
-
-
-

--- a/app/coffee/Features/User/UserRegistrationHandler.coffee
+++ b/app/coffee/Features/User/UserRegistrationHandler.coffee
@@ -4,7 +4,6 @@ User = require("../../models/User").User
 UserCreator = require("./UserCreator")
 AuthenticationManager = require("../Authentication/AuthenticationManager")
 NewsLetterManager = require("../Newsletter/NewsletterManager")
-EmailHandler = require("../Email/EmailHandler")
 async = require("async")
 logger = require("logger-sharelatex")
 
@@ -65,7 +64,9 @@ module.exports =
 				async.series [
 					(cb)-> User.update {_id: user._id}, {"$set":{holdingAccount:false}}, cb
 					(cb)-> AuthenticationManager.setUserPassword user._id, userDetails.password, cb
-					(cb)-> NewsLetterManager.subscribe user, cb
+					(cb)-> 
+						NewsLetterManager.subscribe user, ->
+						cb() #this can be slow, just fire it off
 				], (err)->
 					logger.log user: user, "registered"
 					callback(err, user)

--- a/app/coffee/Features/User/UserRegistrationHandler.coffee
+++ b/app/coffee/Features/User/UserRegistrationHandler.coffee
@@ -66,12 +66,6 @@ module.exports =
 					(cb)-> User.update {_id: user._id}, {"$set":{holdingAccount:false}}, cb
 					(cb)-> AuthenticationManager.setUserPassword user._id, userDetails.password, cb
 					(cb)-> NewsLetterManager.subscribe user, cb
-					(cb)->
-						emailOpts =
-							first_name:user.first_name
-							to: user.email
-							auth_token:user.auth_token
-						EmailHandler.sendEmail "welcome", emailOpts, cb
 				], (err)->
 					logger.log user: user, "registered"
 					callback(err, user)

--- a/app/coffee/Features/User/UserRegistrationHandler.coffee
+++ b/app/coffee/Features/User/UserRegistrationHandler.coffee
@@ -4,6 +4,7 @@ User = require("../../models/User").User
 UserCreator = require("./UserCreator")
 AuthenticationManager = require("../Authentication/AuthenticationManager")
 NewsLetterManager = require("../Newsletter/NewsletterManager")
+EmailHandler = require("../Email/EmailHandler")
 async = require("async")
 logger = require("logger-sharelatex")
 

--- a/app/coffee/Features/User/UserRegistrationHandler.coffee
+++ b/app/coffee/Features/User/UserRegistrationHandler.coffee
@@ -64,7 +64,7 @@ module.exports =
 				async.series [
 					(cb)-> User.update {_id: user._id}, {"$set":{holdingAccount:false}}, cb
 					(cb)-> AuthenticationManager.setUserPassword user._id, userDetails.password, cb
-					(cb)-> 
+					(cb)->
 						NewsLetterManager.subscribe user, ->
 						cb() #this can be slow, just fire it off
 				], (err)->

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -45,7 +45,7 @@ module.exports = class Router
 			app.all '*', AuthenticationController.requireGlobalLogin
 
 		app.use(app.router)
-		
+
 		app.get  '/login', UserPagesController.loginPage
 		AuthenticationController.addEndpointToLoginWhitelist '/login'
 
@@ -54,17 +54,27 @@ module.exports = class Router
 		app.get  '/restricted', SecurityManager.restricted
 
 		# Left as a placeholder for implementing a public register page
-		app.get  '/register', UserPagesController.registerPage
+		app.get  '/register', UserPagesController.publicRegisterPage
+		app.post '/register', UserController.publicRegister
 		AuthenticationController.addEndpointToLoginWhitelist '/register'
+
+		app.get '/confirm', UserPagesController.confirmRegistrationPage
+		app.post '/confirm', ( (req,res,next) ->
+			UserController.confirmRegistration req, res, (error) ->
+				res.send message:
+					text:error,
+					type: "error"
+		)
 
 		EditorRouter.apply(app)
 		CollaboratorsRouter.apply(app)
+
 		SubscriptionRouter.apply(app)
 		UploadsRouter.apply(app)
 		PasswordResetRouter.apply(app)
 		StaticPagesRouter.apply(app)
 		RealTimeProxyRouter.apply(app)
-		
+
 		Modules.applyRouter(app)
 
 		app.get '/blog', BlogController.getIndexPage
@@ -141,7 +151,7 @@ module.exports = class Router
 		app.del  '/user/:user_id/update/*', AuthenticationController.httpAuth, TpdsController.deleteUpdate
 		app.ignoreCsrf('post', '/user/:user_id/update/*')
 		app.ignoreCsrf('delete', '/user/:user_id/update/*')
-		
+
 		app.post '/project/:project_id/contents/*', AuthenticationController.httpAuth, TpdsController.updateProjectContents
 		app.del  '/project/:project_id/contents/*', AuthenticationController.httpAuth, TpdsController.deleteProjectContents
 		app.ignoreCsrf('post', '/project/:project_id/contents/*')
@@ -152,7 +162,7 @@ module.exports = class Router
 
 		app.get  "/project/:Project_id/messages", SecurityManager.requestCanAccessProject, ChatController.getMessages
 		app.post "/project/:Project_id/messages", SecurityManager.requestCanAccessProject, ChatController.sendMessage
-		
+
 		app.get  /learn(\/.*)?/, WikiController.getPage
 
 		#Admin Stuff

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -151,7 +151,7 @@ module.exports = class Router
 		app.del  '/user/:user_id/update/*', AuthenticationController.httpAuth, TpdsController.deleteUpdate
 		app.ignoreCsrf('post', '/user/:user_id/update/*')
 		app.ignoreCsrf('delete', '/user/:user_id/update/*')
-
+		
 		app.post '/project/:project_id/contents/*', AuthenticationController.httpAuth, TpdsController.updateProjectContents
 		app.del  '/project/:project_id/contents/*', AuthenticationController.httpAuth, TpdsController.deleteProjectContents
 		app.ignoreCsrf('post', '/project/:project_id/contents/*')

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -65,6 +65,8 @@ module.exports = class Router
 					text:error,
 					type: "error"
 		)
+		AuthenticationController.addEndpointToLoginWhitelist '/confirm'
+
 
 		EditorRouter.apply(app)
 		CollaboratorsRouter.apply(app)

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -45,7 +45,7 @@ module.exports = class Router
 			app.all '*', AuthenticationController.requireGlobalLogin
 
 		app.use(app.router)
-
+		
 		app.get  '/login', UserPagesController.loginPage
 		AuthenticationController.addEndpointToLoginWhitelist '/login'
 
@@ -53,7 +53,7 @@ module.exports = class Router
 		app.get  '/logout', UserController.logout
 		app.get  '/restricted', SecurityManager.restricted
 
-		# Left as a placeholder for implementing a public register page
+		# Public register page
 		app.get  '/register', UserPagesController.publicRegisterPage
 		app.post '/register', UserController.publicRegister
 		AuthenticationController.addEndpointToLoginWhitelist '/register'
@@ -67,16 +67,14 @@ module.exports = class Router
 		)
 		AuthenticationController.addEndpointToLoginWhitelist '/confirm'
 
-
 		EditorRouter.apply(app)
 		CollaboratorsRouter.apply(app)
-
 		SubscriptionRouter.apply(app)
 		UploadsRouter.apply(app)
 		PasswordResetRouter.apply(app)
 		StaticPagesRouter.apply(app)
 		RealTimeProxyRouter.apply(app)
-
+		
 		Modules.applyRouter(app)
 
 		app.get '/blog', BlogController.getIndexPage
@@ -164,7 +162,7 @@ module.exports = class Router
 
 		app.get  "/project/:Project_id/messages", SecurityManager.requestCanAccessProject, ChatController.getMessages
 		app.post "/project/:Project_id/messages", SecurityManager.requestCanAccessProject, ChatController.sendMessage
-
+		
 		app.get  /learn(\/.*)?/, WikiController.getPage
 
 		#Admin Stuff

--- a/app/views/user/confirm.jade
+++ b/app/views/user/confirm.jade
@@ -1,0 +1,33 @@
+extends ../layout
+
+block content
+	.content.content-alt
+		.container
+			.row
+				.col-md-6.col-md-offset-3.col-lg-4.col-lg-offset-4
+					.card
+						.page-header
+							h1 #{translate("Confirm Registration")}
+							div An email with a confirmation token should arrive to your inbox soon. Please click on the link in the email or enter the confirmation token below.
+						form(async-form="confirm", name="confirmForm", action="/confirm", ng-cloak)
+							input(name='_csrf', type='hidden', value=csrfToken)
+							input(name='redir', type='hidden', value=redir)
+							form-messages(for="confirmForm")
+							.form-group
+								label(for='auth_token') #{translate("Confirmation Token")}
+								input.form-control(
+									type='text',
+									name='auth_token',
+									placeholder="",
+									required,
+									ng-model="auth_token"
+								)
+								span.small.text-primary(ng-show="confirmForm.auth_token.$invalid && confirmForm.auth_token.$dirty")
+									| #{translate("required")}
+							.actions
+								button.btn-primary.btn(
+									type='submit'
+									ng-disabled="confirmForm.inflight"
+								)
+									span(ng-show="!confirmForm.inflight") #{translate("Confirm Registration")}
+									span(ng-show="confirmForm.inflight") #{translate("confirming registration")}...

--- a/app/views/user/register.jade
+++ b/app/views/user/register.jade
@@ -20,47 +20,47 @@ block content
 					.card
 						.page-header
 							h1 #{translate("register")}
-				if allowPublicRegistration
-						form(async-form="register", name="registerForm", action="/register", ng-cloak)
-							input(name='_csrf', type='hidden', value=csrfToken)
-							input(name='redir', type='hidden', value=redir)
-							form-messages(for="registerForm")
-							.form-group
-								label(for='email') #{translate("email")}
-								input.form-control(
-									type='email',
-									name='email',
-									placeholder="#{example_email}",
-									required,
-									ng-model="email",
-									ng-init="email = #{JSON.stringify(new_email)}",
-									ng-model-options="{ updateOn: 'blur' }",
-									focus="true"
-								)
-								span.small.text-primary(ng-show="registerForm.email.$invalid && registerForm.email.$dirty")
-									| #{translate("must_be_email_address")}
-								if restrict_domain
-									div.small (Only emails ending with @#{domain} accepted.)
-							.form-group
-								label(for='password') #{translate("password")}
-								input.form-control(
-									type='password',
-									name='password',
-									placeholder="********",
-									required,
-									ng-model="password"
-								)
-								span.small.text-primary(ng-show="registerForm.password.$invalid && registerForm.password.$dirty")
-									| #{translate("required")}
-							.actions
-								button.btn-primary.btn(
-									type='submit'
-									ng-disabled="registerForm.inflight"
-								)
-									span(ng-show="!registerForm.inflight") #{translate("register")}
-									span(ng-show="registerForm.inflight") #{translate("registering")}...
-				else
-						p
-							| Please contact
-							strong #{settings.adminEmail}
-							| to create an account.
+							if allowPublicRegistration
+									form(async-form="register", name="registerForm", action="/register", ng-cloak)
+										input(name='_csrf', type='hidden', value=csrfToken)
+										input(name='redir', type='hidden', value=redir)
+										form-messages(for="registerForm")
+										.form-group
+											label(for='email') #{translate("email")}
+											input.form-control(
+												type='email',
+												name='email',
+												placeholder="#{example_email}",
+												required,
+												ng-model="email",
+												ng-init="email = #{JSON.stringify(new_email)}",
+												ng-model-options="{ updateOn: 'blur' }",
+												focus="true"
+											)
+											span.small.text-primary(ng-show="registerForm.email.$invalid && registerForm.email.$dirty")
+												| #{translate("must_be_email_address")}
+											if restrict_domain
+												div.small (Only emails ending with @#{domain} accepted.)
+										.form-group
+											label(for='password') #{translate("password")}
+											input.form-control(
+												type='password',
+												name='password',
+												placeholder="********",
+												required,
+												ng-model="password"
+											)
+											span.small.text-primary(ng-show="registerForm.password.$invalid && registerForm.password.$dirty")
+												| #{translate("required")}
+										.actions
+											button.btn-primary.btn(
+												type='submit'
+												ng-disabled="registerForm.inflight"
+											)
+												span(ng-show="!registerForm.inflight") #{translate("register")}
+												span(ng-show="registerForm.inflight") #{translate("registering")}...
+							else
+									p
+										| Please contact
+										strong #{settings.adminEmail}
+										| to create an account.

--- a/app/views/user/register.jade
+++ b/app/views/user/register.jade
@@ -20,7 +20,47 @@ block content
 					.card
 						.page-header
 							h1 #{translate("register")}
+				if allowPublicRegistration
+						form(async-form="register", name="registerForm", action="/register", ng-cloak)
+							input(name='_csrf', type='hidden', value=csrfToken)
+							input(name='redir', type='hidden', value=redir)
+							form-messages(for="registerForm")
+							.form-group
+								label(for='email') #{translate("email")}
+								input.form-control(
+									type='email',
+									name='email',
+									placeholder="#{example_email}",
+									required,
+									ng-model="email",
+									ng-init="email = #{JSON.stringify(new_email)}",
+									ng-model-options="{ updateOn: 'blur' }",
+									focus="true"
+								)
+								span.small.text-primary(ng-show="registerForm.email.$invalid && registerForm.email.$dirty")
+									| #{translate("must_be_email_address")}
+								if restrict_domain
+									div.small (Only emails ending with @#{domain} accepted.)
+							.form-group
+								label(for='password') #{translate("password")}
+								input.form-control(
+									type='password',
+									name='password',
+									placeholder="********",
+									required,
+									ng-model="password"
+								)
+								span.small.text-primary(ng-show="registerForm.password.$invalid && registerForm.password.$dirty")
+									| #{translate("required")}
+							.actions
+								button.btn-primary.btn(
+									type='submit'
+									ng-disabled="registerForm.inflight"
+								)
+									span(ng-show="!registerForm.inflight") #{translate("register")}
+									span(ng-show="registerForm.inflight") #{translate("registering")}...
+				else
 						p
-							| Please contact 
-							strong #{settings.adminEmail} 
+							| Please contact
+							strong #{settings.adminEmail}
 							| to create an account.

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -128,6 +128,32 @@ module.exports =
 
 	httpAuthUsers: httpAuthUsers
 
+
+	# Allow public registration
+	# -------------------------
+	# If set to true, people can use the registration form to register
+	# a new user; otherwise, only admin users can add new users
+	allowPublicRegistration: true
+
+	# Limit Registration
+	# ----------------
+	# If you run sharelatex locally you might want to limit the registration
+	# of new users to users with an email in your domain.
+	signupDomain: "ff.cuni.cz"
+
+	# Require registration confirmation
+	# ----------------
+	# Require users to click on a registration link in the registration email
+	# they receive before their account is activated. This, e.g., proves
+	# that their e-mail address exists and that they have access to it
+	#
+	# Important Note: If you enable this, be sure to configure a mail transport
+	# and set lifcycle to true. Otherwise people won't be able to register
+	# since they will not get their registration links.
+	requireRegistrationConfirmation: true
+
+
+
 	# Default features
 	# ----------------
 	#
@@ -190,7 +216,13 @@ module.exports =
 	#	parameters:
 	#		AWSAccessKeyID: ""
 	#		AWSSecretKey: ""
-
+	email:
+		fromAddress: "sharelatex@temno.eu"
+		replyTo: "sharelatex@temno.eu"
+		lifecycle: true
+		transport: "sendmail"
+		parameters:
+			path:"/usr/local/bin/sendmail.sh"
 
 	# Third party services
 	# --------------------

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -102,7 +102,7 @@ module.exports =
 			url: "http://localhost:8080/json"
 		realTime:
 			url: "http://localhost:3026"
-			
+
 	templates:
 		user_id: process.env.TEMPLATES_USER_ID or "5395eb7aad1f29a88756c7f2"
 		showSocialButtons: false
@@ -139,7 +139,7 @@ module.exports =
 	# ----------------
 	# If you run sharelatex locally you might want to limit the registration
 	# of new users to users with an email in your domain.
-	signupDomain: "ff.cuni.cz"
+	signupDomain: "example.com"
 
 	# Require registration confirmation
 	# ----------------
@@ -175,7 +175,7 @@ module.exports =
 
 	# i18n
 	# ------
-	# 
+	#
 	i18n:
 		subdomainLang:
 			www: {lngCode:"en", url: siteUrl}
@@ -184,7 +184,7 @@ module.exports =
 	# Spelling languages
 	# ------------------
 	#
-	# You must have the corresponding aspell package installed to 
+	# You must have the corresponding aspell package installed to
 	# be able to use a language.
 	languages: [
 		{name: "English", code: "en"},
@@ -216,13 +216,7 @@ module.exports =
 	#	parameters:
 	#		AWSAccessKeyID: ""
 	#		AWSSecretKey: ""
-	email:
-		fromAddress: "sharelatex@temno.eu"
-		replyTo: "sharelatex@temno.eu"
-		lifecycle: true
-		transport: "sendmail"
-		parameters:
-			path:"/usr/local/bin/sendmail.sh"
+	
 
 	# Third party services
 	# --------------------
@@ -238,7 +232,7 @@ module.exports =
 	# analytics:
 	# 	ga:
 	# 		token: ""
-	# 
+	#
 	# ShareLaTeX's help desk is provided by tenderapp.com
 	# tenderUrl: ""
 	#
@@ -272,10 +266,10 @@ module.exports =
 	# then set this to true to allow it to correctly detect the forwarded IP
 	# address and http/https protocol information.
 	behindProxy: false
-	
+
 	# Cookie max age (in milliseconds). Set to false for a browser session.
 	cookieSessionLength: 5 * 24 * 60 * 60 * 1000 # 5 days
-	
+
 	# Should we allow access to any page without logging in? This includes
 	# public projects, /learn, /templates, about pages, etc.
 	allowPublicAccess: false
@@ -288,11 +282,11 @@ module.exports =
 		# them to disk here).
 		dumpFolder: Path.resolve __dirname + "/../data/dumpFolder"
 		uploadFolder: Path.resolve __dirname + "/../data/uploads"
-	
+
 	# Automatic Snapshots
 	# -------------------
 	automaticSnapshots:
-		# How long should we wait after the user last edited to 
+		# How long should we wait after the user last edited to
 		# take a snapshot?
 		waitTimeAfterLastEdit: 5 * minutes
 		# Even if edits are still taking place, this is maximum
@@ -308,13 +302,13 @@ module.exports =
 	# 	user: ""
 	# 	password: ""
 	# 	projectId: ""
-	
+
 	appName: "ShareLaTeX (Community Edition)"
 	adminEmail: "placeholder@example.com"
 
 	nav:
 		title: "ShareLaTeX Community Edition"
-		
+
 		left_footer: [{
 			text: "Powered by <a href='https://www.sharelatex.com'>ShareLaTeX</a> © 2014"
 		}]
@@ -349,7 +343,7 @@ module.exports =
 				url: "/logout"
 			}]
 		}]
-	
+
 #	templates: [{
 #		name : "cv_or_resume",
 #		url : "/templates/cv"
@@ -378,14 +372,14 @@ module.exports =
 		"/templates/index": "/templates/"
 
 	proxyUrls: {}
-	
+
 	reloadModuleViewsOnEachRequest: true
 
 	# ShareLaTeX Server Pro options (https://www.sharelatex.com/university/onsite.html)
 	# ----------
 
 
-	
+
 	# ldap:
 	# 	host: 'ldap://ldap.forumsys.com'
 	# 	dnObj: 'uid'
@@ -394,5 +388,3 @@ module.exports =
 	# 	fieldName: 'LDAP User'
 	# 	placeholder: 'LDAP User ID'
 	# 	emailAtt: 'mail'
-
-

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -102,7 +102,7 @@ module.exports =
 			url: "http://localhost:8080/json"
 		realTime:
 			url: "http://localhost:3026"
-
+			
 	templates:
 		user_id: process.env.TEMPLATES_USER_ID or "5395eb7aad1f29a88756c7f2"
 		showSocialButtons: false
@@ -175,7 +175,7 @@ module.exports =
 
 	# i18n
 	# ------
-	#
+	# 
 	i18n:
 		subdomainLang:
 			www: {lngCode:"en", url: siteUrl}
@@ -184,7 +184,7 @@ module.exports =
 	# Spelling languages
 	# ------------------
 	#
-	# You must have the corresponding aspell package installed to
+	# You must have the corresponding aspell package installed to 
 	# be able to use a language.
 	languages: [
 		{name: "English", code: "en"},
@@ -216,7 +216,7 @@ module.exports =
 	#	parameters:
 	#		AWSAccessKeyID: ""
 	#		AWSSecretKey: ""
-	
+
 
 	# Third party services
 	# --------------------
@@ -232,7 +232,7 @@ module.exports =
 	# analytics:
 	# 	ga:
 	# 		token: ""
-	#
+	# 
 	# ShareLaTeX's help desk is provided by tenderapp.com
 	# tenderUrl: ""
 	#
@@ -266,10 +266,10 @@ module.exports =
 	# then set this to true to allow it to correctly detect the forwarded IP
 	# address and http/https protocol information.
 	behindProxy: false
-
+	
 	# Cookie max age (in milliseconds). Set to false for a browser session.
 	cookieSessionLength: 5 * 24 * 60 * 60 * 1000 # 5 days
-
+	
 	# Should we allow access to any page without logging in? This includes
 	# public projects, /learn, /templates, about pages, etc.
 	allowPublicAccess: false
@@ -282,11 +282,11 @@ module.exports =
 		# them to disk here).
 		dumpFolder: Path.resolve __dirname + "/../data/dumpFolder"
 		uploadFolder: Path.resolve __dirname + "/../data/uploads"
-
+	
 	# Automatic Snapshots
 	# -------------------
 	automaticSnapshots:
-		# How long should we wait after the user last edited to
+		# How long should we wait after the user last edited to 
 		# take a snapshot?
 		waitTimeAfterLastEdit: 5 * minutes
 		# Even if edits are still taking place, this is maximum
@@ -302,13 +302,13 @@ module.exports =
 	# 	user: ""
 	# 	password: ""
 	# 	projectId: ""
-
+	
 	appName: "ShareLaTeX (Community Edition)"
 	adminEmail: "placeholder@example.com"
 
 	nav:
 		title: "ShareLaTeX Community Edition"
-
+		
 		left_footer: [{
 			text: "Powered by <a href='https://www.sharelatex.com'>ShareLaTeX</a> © 2014"
 		}]
@@ -343,7 +343,7 @@ module.exports =
 				url: "/logout"
 			}]
 		}]
-
+	
 #	templates: [{
 #		name : "cv_or_resume",
 #		url : "/templates/cv"
@@ -372,14 +372,14 @@ module.exports =
 		"/templates/index": "/templates/"
 
 	proxyUrls: {}
-
+	
 	reloadModuleViewsOnEachRequest: true
 
 	# ShareLaTeX Server Pro options (https://www.sharelatex.com/university/onsite.html)
 	# ----------
 
 
-
+	
 	# ldap:
 	# 	host: 'ldap://ldap.forumsys.com'
 	# 	dnObj: 'uid'


### PR DESCRIPTION
# Summary
Implement a public registration page, optionally requiring confirmation & restriction of logins to emails in a particular domain.

# Detailed description
If the  `allowPublicRegistration` variable is set to true (in settings.coffee), the original registration form is enabled allowing anyone to register for an account. 

Moreover, if the `requireRegistrationConfirmation` variable is set to true, new registrations are not activated by default (the activated state is saved in the user attribute `confirmed` in the mongo dbase) but people have to click on a link that is sent to their e-mail address (or enter the confirmation token into a form found at /confirm). This proves that they really control the e-mail address they logged in with.  

The way confirmation is implemented is by reusing the `authToken` user attribute: when a new user is created, a new random token is generated and embedded into the link. When the user confirms the registration by following the link, this token is cleared.

If the `signupDomain` variable is set then registration of new users is restricted to emails in the
given domain.

# Caveat

First of all I'd like to thank you (sharelatex authors) for this excellent piece of software! Also I am new to the code base and I am not sure what the conventions are and whether the way I implemented the features is the right way. Also I am not sure whether the features are something you are interested in at all. So feel free to reject this :-)