### PR TITLE
prevent loading error for ace language tools extension in development

### DIFF
--- a/app/views/project/editor.jade
+++ b/app/views/project/editor.jade
@@ -99,6 +99,9 @@ block content
 				},
 				"ace/ext-searchbox": {
 					deps: ["ace/ace"]
+				},
+				"ace/ext-language_tools": {
+					deps: ["ace/ace"]
 				}
 			},
 			config:{


### PR DESCRIPTION
Use a requirejs shim to make sure ace language tools have ace already loaded.

Have checked the source with git grep to make sure searchbox and language tools are the only two modules we are currently using.