### PR TITLE
allow public sharing of images via urls

### DIFF
--- a/app/coffee/Features/Compile/CompileController.coffee
+++ b/app/coffee/Features/Compile/CompileController.coffee
@@ -118,3 +118,14 @@ module.exports = CompileController =
 		proxy.pipe(res)
 		proxy.on "error", (error) ->
 			logger.warn err: error, url: url, "CLSI proxy error"
+
+	getClsiStream: (project_id, path, callback) ->
+		# quick and dirty version
+		compilerUrl = Settings.apis.clsi.url
+		url = "#{compilerUrl}/project/#{project_id}/output/#{path}"
+		logger.log url: url, "proxying to CLSI"
+		oneMinute = 60 * 1000
+		# the base request
+		options = { url: url, method: 'GET',	timeout: oneMinute }
+		proxy = request(options)
+		callback null, proxy

--- a/app/coffee/Features/FileStore/FileStoreHandler.coffee
+++ b/app/coffee/Features/FileStore/FileStoreHandler.coffee
@@ -6,23 +6,28 @@ settings = require("settings-sharelatex")
 oneMinInMs = 60 * 1000
 fiveMinsInMs = oneMinInMs * 5
 
-module.exports =
+module.exports = FileStoreHandler =
 
 	uploadFileFromDisk: (project_id, file_id, fsPath, callback)->
 		logger.log project_id:project_id, file_id:file_id, fsPath:fsPath, "uploading file from disk"
 		readStream = fs.createReadStream(fsPath)
+		FileStoreHandler.putFileStream project_id, file_id, readStream, callback
+
+	putFileStream: (project_id, file_id, readStream, callback)->
+		logger.log project_id:project_id, file_id:file_id, "putting stream"
 		opts =
 			method: "post"
 			uri: @_buildUrl(project_id, file_id)
 			timeout:fiveMinsInMs
 		writeStream = request(opts)
 		readStream.pipe writeStream
+		# FIXME: potential double callbacks
 		writeStream.on "end", callback
 		readStream.on "error", (err)->
-			logger.err err:err, project_id:project_id, file_id:file_id, fsPath:fsPath, "something went wrong on the read stream of uploadFileFromDisk"
+			logger.err err:err, project_id:project_id, file_id:file_id, fsPath:fsPath, "something went wrong on the read stream of putFileStream"
 			callback err
 		writeStream.on "error", (err)->
-			logger.err err:err, project_id:project_id, file_id:file_id, fsPath:fsPath, "something went wrong on the write stream of uploadFileFromDisk"
+			logger.err err:err, project_id:project_id, file_id:file_id, fsPath:fsPath, "something went wrong on the write stream of putFileStream"
 			callback err
 
 	getFileStream: (project_id, file_id, query, callback)->

--- a/app/coffee/Features/FileStore/FileStoreHandler.coffee
+++ b/app/coffee/Features/FileStore/FileStoreHandler.coffee
@@ -20,7 +20,6 @@ module.exports = FileStoreHandler =
 			uri: @_buildUrl(project_id, file_id)
 			timeout:fiveMinsInMs
 		writeStream = request(opts)
-		readStream.pipe writeStream
 		# FIXME: potential double callbacks
 		writeStream.on "end", callback
 		readStream.on "error", (err)->
@@ -29,6 +28,7 @@ module.exports = FileStoreHandler =
 		writeStream.on "error", (err)->
 			logger.err err:err, project_id:project_id, file_id:file_id, fsPath:fsPath, "something went wrong on the write stream of putFileStream"
 			callback err
+		readStream.pipe writeStream
 
 	getFileStream: (project_id, file_id, query, callback)->
 		logger.log project_id:project_id, file_id:file_id, query:query, "getting file stream from file store"

--- a/app/coffee/Features/Link/LinkController.coffee
+++ b/app/coffee/Features/Link/LinkController.coffee
@@ -1,0 +1,63 @@
+logger = require('logger-sharelatex')
+FileStoreHandler = require("../FileStore/FileStoreHandler")
+CompileController = require("../Compile/CompileController")
+LinkCreator = require("./LinkCreator")
+Settings = require "settings-sharelatex"
+request = require "request"
+Link = require("../../models/Link").Link
+
+module.exports =
+	generateLink : (req, res) ->
+		user_id = req.session.user._id
+		project_id = req.params.Project_id # this has been checked by the middleware
+		path = req.body.path # this will be checked by the clsi
+		logger.log project_id: project_id, user_id: user_id, path: path, "generate link"
+		# Copy file from clsi to filestore using link._id as the identifier
+		CompileController.getClsiStream project_id, path, (err, srcStream) ->
+			# Get the stream from the CLSI
+			srcStream.on "error", (err) ->
+				logger.err err:err, "error on get stream"
+				res.status(500).send {error: err}
+			srcStream.pause()
+			srcStream.on "response", (response) ->
+				# N.B. make sure the srcStream/response stream are discard if needed
+				logger.err statusCode:response.statusCode, "get response code"
+				# Create the link in mongo
+				LinkCreator.createNewLink {user_id, project_id, path}, (err, link) ->
+					if err?
+						srcStream.resume()
+						logger.err err:err, "error creating link"
+						return res.status(500).send {error: err}
+					logger.log link, "created new link"
+					# Send the stream to the filestore at /project/:project_id/public/:public_file_id
+					destUrl = "#{Settings.apis.filestore.url}/project/#{project_id}/public/#{link._id}"
+					destStream = request.post destUrl, {timeout: 60*1000, json:true}, (err, response, body) ->
+						if err? or response.statusCode != 200
+							res.status(response?.statusCode || 500).send { error: body }
+						else
+							short_id = link.public_id.toString(36)  # use base 36 for shortened url
+							res.send {
+								link: "#{Settings.publicLinkUrl || Settings.siteUrl}/public/#{short_id}/#{link.path}"
+							}
+					srcStream.pipe(destStream)
+					srcStream.resume()
+
+	getFile : (req, res) ->
+		# need to be able to put this on a cdn, so allow for a separate subdomain
+		public_id = req.params.public_id
+		if not public_id.match(/^[0-9a-zA-Z]+$/)
+			return res.status(404).send("Invalid link id")
+		Link.findOne {public_id: parseInt(public_id, 36)}, (err, link) ->
+			if err?
+				return res.status(404).send(err)
+			url = "#{Settings.apis.filestore.url}/project/#{link.project_id}/public/#{link._id}"
+			oneMinute = 60 * 1000
+			options = { url: url, method: req.method,	timeout: oneMinute }
+			proxy = request.get url
+			proxy.on "error", (err) ->
+				logger.warn err: err, url: url, "filestore proxy error"
+				res.status(500).end()
+			res.setHeader "Cache-Control", "public, max-age=86400"
+			res.setHeader "Last-Modified", link.created.toUTCString()
+			res.setHeader "ETag", link._id
+			proxy.pipe(res)

--- a/app/coffee/Features/Link/LinkCreator.coffee
+++ b/app/coffee/Features/Link/LinkCreator.coffee
@@ -1,0 +1,11 @@
+Link = require("../../models/Link").Link
+
+module.exports =
+
+	createNewLink: (opts, callback)->
+		link = new Link()
+		link.path = opts.path
+		link.project_id = opts.project_id
+		link.user_id = opts.user_id
+		link.save (err)->
+			callback(err, link)

--- a/app/coffee/infrastructure/Mongoose.coffee
+++ b/app/coffee/infrastructure/Mongoose.coffee
@@ -1,0 +1,16 @@
+mongoose = require('mongoose')
+Settings = require 'settings-sharelatex'
+logger = require('logger-sharelatex')
+
+mongoose.connect(Settings.mongo.url, server: poolSize: 10)
+
+mongoose.connection.on 'connected', () ->
+	logger.log {url:Settings.mongo.url}, 'mongoose default connection open'
+
+mongoose.connection.on 'error', (err) ->
+	logger.err err:err, 'mongoose error on default connection';
+
+mongoose.connection.on 'disconnected', () ->
+	logger.log 'mongoose default connection disconnected'
+
+module.exports = mongoose

--- a/app/coffee/infrastructure/Server.coffee
+++ b/app/coffee/infrastructure/Server.coffee
@@ -14,6 +14,8 @@ rclient = redis.createClient(Settings.redis.web)
 RedisStore = require('connect-redis')(express)
 sessionStore = new RedisStore(client:rclient)
 
+Mongoose = require("./Mongoose")
+
 cookieParser = express.cookieParser(Settings.security.sessionSecret)
 oneDayInMilliseconds = 86400000
 RedirectManager = require("./RedirectManager")

--- a/app/coffee/models/Link.coffee
+++ b/app/coffee/models/Link.coffee
@@ -1,0 +1,23 @@
+mongoose = require 'mongoose'
+Settings = require 'settings-sharelatex'
+autoIncrement = require 'mongoose-auto-increment'
+
+autoIncrement.initialize(mongoose)
+
+Schema = mongoose.Schema
+ObjectId = Schema.ObjectId
+
+LinkSchema = new Schema
+	path          :     { type:String, default:'' }
+	created       :     { type:Date, default: () -> new Date() }
+	project_id    :     { type:ObjectId }
+	user_id       :     { type:ObjectId }
+
+LinkSchema.plugin autoIncrement.plugin, { model: 'Link', field: 'public_id', startAt: 100 }
+
+LinkSchema.index {public_id : 1}, {unique: true}
+
+Link = mongoose.model 'Link', LinkSchema
+
+exports.Link = mongoose.model 'Link'
+exports.LinkSchema = LinkSchema

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -34,6 +34,7 @@ Modules = require "./infrastructure/Modules"
 RateLimiterMiddlewear = require('./Features/Security/RateLimiterMiddlewear')
 RealTimeProxyRouter = require('./Features/RealTimeProxy/RealTimeProxyRouter')
 AnalyticsMiddlewear = require "./Features/Analytics/AnalyticsMiddlewear"
+LinkController = require("./Features/Link/LinkController")
 
 logger = require("logger-sharelatex")
 _ = require("underscore")
@@ -163,6 +164,9 @@ module.exports = class Router
 
 		app.get  "/project/:Project_id/messages", SecurityManager.requestCanAccessProject, ChatController.getMessages
 		app.post "/project/:Project_id/messages", SecurityManager.requestCanAccessProject, ChatController.sendMessage
+
+		app.post  "/project/:Project_id/link", SecurityManager.requestCanAccessProject, LinkController.generateLink
+		app.get   "/public/:public_id/*", LinkController.getFile # public image links
 		
 		app.get  /learn(\/.*)?/, AnalyticsMiddlewear.injectIntercomDetails, WikiController.getPage
 

--- a/app/views/project/editor/link-image.jade
+++ b/app/views/project/editor/link-image.jade
@@ -1,0 +1,27 @@
+script(type='text/ng-template', id='linkImageModalTemplate')
+	.modal-header
+		h3 Publish output file
+	.modal-body.link-image-modal
+		.thumbnail
+			img(ng-src="{{inputs.url}}")
+		form.form-inline.toolbar.toolbar-borderless.row-spaced
+			span.text-monospace(ng-if="output.url")
+				input.form-control.link-url(
+					ng-model="output.url",
+					focus-on="generat-link-done"
+				)
+			.alert(ng-if="error")
+				span Error generating link
+			button(
+				ng-if="!output.url && !error"
+				ng-click="generateLink()"
+				ng-disabled="generating"
+			).btn.btn-primary
+				span Generate public link
+				span(ng-show="generating") &nbsp;
+					i.fa.fa-refresh(
+						ng-class="{'fa-spin': generating }"
+					)
+
+	.modal-footer
+		button.btn.btn-primary(ng-click="$close()") Done

--- a/app/views/project/editor/output_panel/script_output.jade
+++ b/app/views/project/editor/output_panel/script_output.jade
@@ -20,6 +20,8 @@ div.full-size(ng-controller="ScriptOutputController")
 			.i.fa.fa-fw.fa-stop
 			|  Stop
 
+	include ../link-image
+
 	div.script-output.main-script-output(scroll-glue)
 		.script-uncompiled(ng-show="uncompiled")
 			| &nbsp;
@@ -61,7 +63,7 @@ div.full-size(ng-controller="ScriptOutputController")
 				div.text-center(ng-show="currentRun.running")
 					i.fa.fa-2x.fa-spin.fa-spinner
 				
-				.download-controls
+				.download-controls(ng-controller="LinkImageController")
 					span.name(ng-show="part.file_type == 'image' && part.path.slice(0,7) != '.output'") {{ part.path }}
 					a(
 						ng-href="{{part.url}}",
@@ -71,6 +73,16 @@ div.full-size(ng-controller="ScriptOutputController")
 						tooltip-placement="bottom"
 					)
 						i.fa.fa-download
+
+					a(
+						ng-href="",
+						ng-click="linkImage(part)"
+						tooltip="Share",
+						tooltip-append-to-body="true",
+						tooltip-placement="bottom"
+					)
+						i.fa.fa-link
+
 
 				img(ng-if="part.file_type == 'image' && !currentRun.running", ng-src="{{part.url}}")
 				div(ng-if="part.file_type != 'image' && !currentRun.running")

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -139,6 +139,8 @@ module.exports =
 		versioning: true
 		compileTimeout: 60
 		compileGroup: "standard"
+		compileMemory: 1000
+		compileCpuShares: 10
 
 	plans: plans = [{
 		planCode: "personal"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mocha": "1.17.1",
     "mongojs": "0.10.1",
     "mongoose": "3.8.8",
+    "mongoose-auto-increment": "3.0.2",
     "node-uuid": "1.4.1",
     "nodemailer": "0.6.1",
     "optimist": "0.6.1",

--- a/public/coffee/ide.coffee
+++ b/public/coffee/ide.coffee
@@ -16,6 +16,7 @@ define [
 	"ide/clone/index"
 	"ide/hotkeys/index"
 	"ide/install/index"
+	"ide/link-image/index"
 	"ide/directives/layout"
 	"ide/services/ide"
 	"ide/services/commandRunner"

--- a/public/coffee/ide/link-image/controllers/LinkImageController.coffee
+++ b/public/coffee/ide/link-image/controllers/LinkImageController.coffee
@@ -1,0 +1,19 @@
+define [
+	"base"
+], (App) ->
+	App.controller "LinkImageController", ($scope, $modal) ->
+		# Keep the scope here rather than in the modal so that we can restore
+		# the modal to it's previous state when we reopen it.
+		$scope.inputs =
+			url: ""
+		$scope.output = {}
+
+		$scope.linkImage = (part) ->
+			$scope.inputs.path = part.path
+			$scope.inputs.url = part.url
+			$modal.open {
+				templateUrl: "linkImageModalTemplate"
+				controller: "LinkImageModalController"
+				size: "lg"
+				scope: $scope
+			}

--- a/public/coffee/ide/link-image/controllers/LinkImageModalController.coffee
+++ b/public/coffee/ide/link-image/controllers/LinkImageModalController.coffee
@@ -1,0 +1,26 @@
+define [
+	"base"
+], (App) ->
+	App.controller "LinkImageModalController", ($scope, $modalInstance, $timeout, $http, ide) ->
+		$modalInstance.opened.then () ->
+			$timeout () ->
+				$scope.$broadcast "open"
+			, 200
+
+		$scope.generateLink = () ->
+			return if $scope.inputs.path == ""
+			$scope.generating = true
+			delete $scope.error
+			request = $http.post "/project/#{ide.$scope.project_id}/link", {
+				path: $scope.inputs.path
+				_csrf: window.csrfToken
+			}
+			request.success (data, status, headers, config) ->
+				console.log "success", data, status, headers, config
+				$scope.generating = false
+				$scope.output.url = data?.link
+				$scope.$broadcast "generate-link-done"
+			request.error  (data, status, headers, config) ->
+				console.log "error", data, status, headers, config
+				$scope.generating = false
+				$scope.error = true

--- a/public/coffee/ide/link-image/index.coffee
+++ b/public/coffee/ide/link-image/index.coffee
@@ -1,0 +1,4 @@
+define [
+	"ide/link-image/controllers/LinkImageController"
+	"ide/link-image/controllers/LinkImageModalController"
+], () ->

--- a/public/stylesheets/app/editor/output.less
+++ b/public/stylesheets/app/editor/output.less
@@ -187,6 +187,7 @@
 			top: -4px;
 			right: 0;
 			display: none;
+			padding: 16px;
 			a {
 				color: @gray-light;
 			}
@@ -195,6 +196,7 @@
 				text-decoration: none;
 			}
 			i.fa {
+				padding: 0 0 0 8px;
 				vertical-align: middle;
 			}
 			.name {
@@ -260,6 +262,25 @@
 			margin-top: -2px;
 		}
 	}
+}
+
+.link-image-modal {
+
+	.thumbnail {
+		text-align: center;
+
+		img {
+			max-width: 70%;
+			max-height: 300px;
+		}
+	}
+	form {
+		text-align: center
+	}
+	input.link-url {
+		width: 70%
+	}
+
 }
 
 .editor-dark {


### PR DESCRIPTION
Add support for short urls for sharing images.  

To create a link post the url to /project/:project_id/lin

The urls have the form www.getdatajoy.com/public/sk212a/foo.png

They are stored in the filestore under a separate s3 bucket

The filestore has been modified to accept  REST requests of the form project/:project_id/public/:public_file_id
