### PR TITLE
Update bcrypt to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "archiver": "0.9.0",
     "async": "0.6.2",
-    "bcrypt": "0.7.5",
+    "bcrypt": "0.8.3",
     "bufferedstream": "1.6.0",
     "connect-redis": "1.4.5",
     "dateformat": "1.0.4-1.2.3",


### PR DESCRIPTION
I'm installing a development environment and came across some build errors while installing bcrypt. Looking at the [bcrypt website](https://www.npmjs.com/package/bcrypt) I found out that the current version would not work on nodejs newer than 0.10. As people will probably use the latest nodejs when installing sharelatex, probably they will face the same problem I did.

Also, may be interesting to set the nodejs supported version in the [installation wiki page](https://github.com/sharelatex/sharelatex/wiki/Setting-up-a-Development-Environment).

This new version compiles successfully on nodejs newer than 0.10.

