### PR TITLE
Fix call to addUserToProject.

### DIFF
--- a/app/coffee/Features/Collaborators/CollaboratorsHandler.coffee
+++ b/app/coffee/Features/Collaborators/CollaboratorsHandler.coffee
@@ -22,7 +22,7 @@ module.exports =
 	changeUsersPrivilegeLevel: (project_id, user_id, newPrivalageLevel, callback = ->)->
 		@removeUserFromProject project_id, user_id, =>
 		  User.findById user_id, (err, user)=>
-			  @addUserToProject project_id, user_id, newPrivalageLevel, callback
+			  @addUserToProject project_id, user.email, newPrivalageLevel, callback
 
 	addUserToProject: (project_id, email, privilegeLevel, callback)->
 		emails = mimelib.parseAddresses(email)


### PR DESCRIPTION
I was working on permissions support in the Sandstorm port, and I noticed that `changeUsersPriviliegeLevel()` does not quite work. This patch seems to fix things.

I ended up not actually needing to use `changeUsersPrivilegeLevel()`, and it looks like it's currently not used anywhere in this repo, so another option might be simply to delete the function.