### PR TITLE
An institution-wise OAuth replacement for login/registration

### DIFF
--- a/app/coffee/Features/Authentication/OAuthController.coffee
+++ b/app/coffee/Features/Authentication/OAuthController.coffee
@@ -1,0 +1,105 @@
+AuthenticationManager = require ("./AuthenticationManager")
+LoginRateLimiter = require("../Security/LoginRateLimiter")
+
+User = require("../../models/User").User
+UserGetter = require "../User/UserGetter"
+UserUpdater = require "../User/UserUpdater"
+UserRegistrationHandler = require "../User/UserRegistrationHandler"
+
+AuthenticationController = require "./AuthenticationController"
+
+Metrics = require('../../infrastructure/Metrics')
+crypto = require("crypto")
+logger = require("logger-sharelatex")
+querystring = require('querystring')
+
+Url = require("url")
+Settings = require "settings-sharelatex"
+basicAuth = require('basic-auth-connect')
+OAuth = require('simple-oauth2');
+Settings = require('settings-sharelatex')
+
+
+OAuthController =
+	login: (req, res, next = (error) ->) ->
+		oauth2 = OAuthController.oauth_core()
+		authorization_uri = oauth2.authCode.authorizeURL({
+		  redirect_uri: OAuthController.redirect_url(),
+		  scope: Settings.oauth.scope,
+		})
+
+		res.redirect(authorization_uri)
+
+	oauth_core: ->
+		credentials = {
+		  clientID: Settings.oauth.client_id,
+		  clientSecret: Settings.oauth.client_secret,
+		  site: Settings.oauth.base_url
+		}
+
+		return OAuth(credentials)
+
+	redirect_url: ->
+		return 'http://localhost:3000/oauth/callback'
+
+	callback: (req, res) ->
+		code = req.query.code
+		oauth2 = OAuthController.oauth_core()
+
+		oauth2.authCode.getToken {
+			  code: code,
+			  redirect_uri: OAuthController.redirect_url()
+
+			},
+
+			(error, result) ->
+		  		if error
+		    		console.log 'Access Token Error', error.message
+		  
+		  		token = oauth2.accessToken.create(result)
+		  		console.log 'token: ', token
+		  		oauth2.api 'GET', '/user', { access_token: token.token.access_token }, (err, data) -> OAuthController.handle_user_data(req, res, err, data)
+   	
+
+	login_user: (req, res, user) ->
+		LoginRateLimiter.recordSuccessfulLogin user.email
+		AuthenticationController._recordSuccessfulLogin user._id
+		AuthenticationController.establishUserSession req, user, (error) ->
+			if error?
+				return error 
+			req.session.justLoggedIn = true
+		logger.log email: user.email, user_id: user._id.toString(), "successful log in"
+		res.redirect Url.parse("/project").path
+
+
+	handle_user_data: (req, res, error, data) ->
+		if error
+    		console.log 'User Data Access Error', error.message
+
+    	console.log(data.principal)
+    	
+    	email = data.principal.email
+    	fname = data.principal.name
+    	sname = data.principal.surname
+
+    	User.findOne email: email, (err, user)->
+			if user?
+    			# handle user perform login
+    			logger.log {email}, "matched existing user via oauth"
+    			OAuthController.login_user user
+    		else
+    			# register user
+    			logger.log {email}, "registering new user via oauth"
+
+    			usr = email: email, password: crypto.randomBytes(32).toString("hex")
+
+				console.log(usr)
+				UserRegistrationHandler.registerNewUser usr, (err, user2) ->
+					if err?
+		    			console.log(err.message)
+					user2.first_name = fname
+					user2.last_name  = sname
+					user2.save()
+					OAuthController.login_user(req, res, user2)
+
+module.exports = OAuthController

--- a/app/coffee/Features/Authentication/OAuthController.coffee
+++ b/app/coffee/Features/Authentication/OAuthController.coffee
@@ -40,7 +40,7 @@ OAuthController =
 		return OAuth(credentials)
 
 	redirect_url: ->
-		return 'http://localhost:3000/oauth/callback'
+		return Settings.apis.web.url + '/oauth/callback'
 
 	callback: (req, res) ->
 		code = req.query.code

--- a/app/coffee/Features/Authentication/OAuthController.coffee
+++ b/app/coffee/Features/Authentication/OAuthController.coffee
@@ -40,7 +40,7 @@ OAuthController =
 		return OAuth(credentials)
 
 	redirect_url: ->
-		return Settings.apis.web.url + '/oauth/callback'
+		return Settings.siteUrl + '/oauth/callback'
 
 	callback: (req, res) ->
 		code = req.query.code

--- a/app/coffee/Features/Authentication/OAuthController.coffee
+++ b/app/coffee/Features/Authentication/OAuthController.coffee
@@ -64,10 +64,10 @@ OAuthController =
 	login_user: (req, res, user) ->
 		LoginRateLimiter.recordSuccessfulLogin user.email
 		AuthenticationController._recordSuccessfulLogin user._id
-		AuthenticationController.establishUserSession req, user, (error) ->
+		req.login user, (error) ->
 			if error?
 				return error 
-			req.session.justLoggedIn = true
+#			req.session.justLoggedIn = true
 		logger.log email: user.email, user_id: user._id.toString(), "successful log in"
 		res.redirect Url.parse("/project").path
 

--- a/app/coffee/Features/User/UserPagesController.coffee
+++ b/app/coffee/Features/User/UserPagesController.coffee
@@ -48,10 +48,14 @@ module.exports =
 					token: req.query.token
 
 	loginPage : (req, res)->
-		res.render 'user/login',
-			title: 'login',
-			redir: req.query.redir,
-			email: req.query.email
+		if !Settings.oauth.is_enabled
+			res.render 'user/login',
+				title: 'login',
+				redir: req.query.redir,
+				email: req.query.email
+		else
+			res.render 'user/login_oauth',
+				redir: '/oauth/login'
 
 	settingsPage : (req, res, next)->
 		user_id = AuthenticationController.getLoggedInUserId(req)

--- a/app/views/user/login_oauth.jade
+++ b/app/views/user/login_oauth.jade
@@ -1,0 +1,13 @@
+extends ../layout
+
+block content
+	.content.content-alt
+		.container
+			.row
+				.col-md-6.col-md-offset-3.col-lg-4.col-lg-offset-4
+					.card
+						.page-header
+							h1 #{translate("log_in")}
+
+						a.btn-primary.btn(href='/oauth/login')  #{translate("Login via OAuth")}
+								

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -418,5 +418,12 @@ module.exports = settings =
 	#	name : "all projects",
 	#	url: "/templates/all"
 	#}]
+	oauth:
+		is_enabled: true
+		client_id: 'sharelatex'
+		client_secret: 'sekret'
+		base_url: 'http://localhost:8080/'
+		scope: 'openid'
+
 
 

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -419,7 +419,7 @@ module.exports = settings =
 	#	url: "/templates/all"
 	#}]
 	oauth:
-		is_enabled: true
+		is_enabled: false
 		client_id: 'sharelatex'
 		client_secret: 'sekret'
 		base_url: 'http://localhost:8080/'

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sanitizer": "0.1.1",
     "sequelize": "^3.2.0",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
-    "simple-oauth2": ">=0.5.1",
+    "simple-oauth2": "0.6.0",
     "sixpack-client": "^1.0.0",
     "temp": "^0.8.3",
     "underscore": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "sanitizer": "0.1.1",
     "sequelize": "^3.2.0",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
+    "simple-oauth2": ">=0.5.1",
     "sixpack-client": "^1.0.0",
     "temp": "^0.8.3",
     "underscore": "1.6.0",

--- a/test/UnitTests/coffee/User/UserPagesControllerTests.coffee
+++ b/test/UnitTests/coffee/User/UserPagesControllerTests.coffee
@@ -10,8 +10,9 @@ describe "UserPagesController", ->
 
 	beforeEach ->
 
-		@settings = {}
-		@user =
+		@settings = { oauth: { is_enabled: false } }
+		@user = 
+
 			_id: @user_id = "kwjewkl"
 			features:{}
 			email: "joe@example.com"


### PR DESCRIPTION
During our work at the ENGINE [1] project - one of the tasks we have at hand is to set up a platform for researchers in the centre with a unified oauth-based login to all parts of the locally hostem platform. We've wanted to be able to use sharelatex with that, so I've added an option to login via oauth2 instead of normal login approach. 

Would you be interested in such a functionality being merged? If so - please comment on what your expectations would be for it to be merged in - should I clean up the code some more, are there any coding guidelines for sharelatex?

What I'm sending here is just my first working version, if oauth enabled in settings it replaces the login form with an oauth login button and then performs the login operation - creating the user and logging in. I'm willing to polish this code some more to your liking, if you feel this kind of functionality is welcome in shareltex. 

[1] http://engine.pwr.edu.pl
