### PR TITLE
Put brackets around the example ca path for ldap starttls support in …

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -396,7 +396,7 @@ module.exports =
 	#	starttls: true
 	#	tlsOptions:
 	#		rejectUnauthorized: false
-	#		ca: '/etc/ldap/ca_certs.pem'
+	#		ca: ['/etc/ldap/ca_certs.pem']
 	
 	#templateLinks: [{
 	#	name : "CV projects",


### PR DESCRIPTION
…the default config. This resolves an issue where the system was breaking the path into an array and trying to act on the first item in that array, "/", rather than the full path.