### PR TITLE
Fix synctex position calculation

### DIFF
--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -353,18 +353,35 @@ define [
 					deferred.reject()
 					return deferred.promise
 
+				# FIXME: this actually works better if it's halfway across the
+				# page (or the visible part of the page). Synctex doesn't
+				# always find the right place in the file when the point is at
+				# the edge of the page, it sometimes returns the start of the
+				# next paragraph instead.
+				h = position.offset.left
+
+				# Compute the vertical position to pass to synctex, which
+				# works with coordinates increasing from the top of the page
+				# down.  This matches the browser's DOM coordinate of the
+				# click point, but the pdf position is measured from the
+				# bottom of the page so we need to invert it.
+				if options.fromPdfPosition and position.pageSize?.height?
+					v = (position.pageSize.height - position.offset.top) or 0 # measure from pdf point (inverted)
+				else
+					v = position.offset.top or 0 # measure from html click position
+
 				# It's not clear exactly where we should sync to if it wasn't directly
 				# clicked on, but a little bit down from the very top seems best.
 				if options.includeVisualOffset
-					position.offset.top = position.offset.top + 80
+					v += 72 # use the same value as in pdfViewer highlighting visual offset
 
 				$http({
 						url: "/project/#{ide.project_id}/sync/pdf",
 						method: "GET",
 						params: {
 							page: position.page + 1
-							h: position.offset.left.toFixed(2)
-							v: position.offset.top.toFixed(2)
+							h: h.toFixed(2)
+							v: v.toFixed(2)
 							clsiserverid:ide.clsiServerId
 							isolated: perUserCompile
 						}
@@ -395,7 +412,7 @@ define [
 
 		$scope.syncToCode = () ->
 			synctex
-				.syncToCode($scope.pdf.position, includeVisualOffset: true)
+				.syncToCode($scope.pdf.position, includeVisualOffset: true, fromPdfPosition: true)
 				.then (data) ->
 					{doc, line} = data
 					ide.editorManager.openDoc(doc, gotoLine: line)

--- a/public/coffee/ide/pdfng/directives/pdfJs.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfJs.coffee
@@ -50,7 +50,11 @@ define [
 						scope.scale = { scaleMode: 'scale_mode_fit_width' }
 
 					if (position = localStorage("pdf.position.#{attrs.key}"))
-						scope.position = { page: +position.page, offset: { "top": +position.offset.top, "left": +position.offset.left } }
+						scope.position =
+							page: +position.page,
+							offset:
+								"top": +position.offset.top
+								"left": +position.offset.left
 
 					#scope.position = pdfListView.getPdfPosition(true)
 

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -187,7 +187,8 @@ define [
 			# console.log 'converted to offset = ', pdfOffset
 			newPosition = {
 				"page": topPageIdx,
-				"offset" : { "top" : pdfOffset[1], "left": 0	}
+				"offset" : { "top" : pdfOffset[1], "left": 0}
+				"pageSize": { "height": viewport.viewBox[3], "width": viewport.viewBox[2] }
 			}
 			return newPosition
 
@@ -208,6 +209,8 @@ define [
 			return $scope.document.getPdfViewport(page.pageNum).then (viewport) ->
 				page.viewport = viewport
 				pageOffset = viewport.convertToViewportPoint(offset.left, offset.top)
+				# if the passed-in position doesn't have the page height/width add them now
+				position.pageSize ?= {"height": viewport.viewBox[3], "width": viewport.viewBox[2]}
 				# console.log 'addition offset =', pageOffset
 				# console.log 'total', pageTop + pageOffset[1]
 				Math.round(pageTop + pageOffset[1] + currentScroll) ## 10 is margin
@@ -515,6 +518,7 @@ define [
 
 					pageNum = scope.pages[first.page].pageNum
 
+					# use a visual offset of 72pt to match the offset in PdfController syncToCode
 					scope.document.getPdfViewport(pageNum).then (viewport) ->
 						position = {
 							page: first.page

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -516,7 +516,15 @@ define [
 
 					first = highlights[0]
 
-					pageNum = scope.pages[first.page].pageNum
+					# switching between split and full pdf views can cause
+					# highlights to appear before rendering
+					if !scope.pages
+						return # ignore highlight scroll if still rendering
+
+					pageNum = scope.pages[first.page]?.pageNum
+
+					if !pageNum?
+						return # ignore highlight scroll if page not found
 
 					# use a visual offset of 72pt to match the offset in PdfController syncToCode
 					scope.document.getPdfViewport(pageNum).then (viewport) ->


### PR DESCRIPTION
Synctex position was inverted when clicking the goto code button.

Changed the parameters to align to visual offsets for going forwards and backwards) (if you go to pdf and back to code you get to the same place)