### PR TITLE
remove scaffolding for per-user compiles so that it is always by default

### DIFF
--- a/app/coffee/Features/Compile/CompileController.coffee
+++ b/app/coffee/Features/Compile/CompileController.coffee
@@ -29,8 +29,6 @@ module.exports = CompileController =
 				options.compiler = req.body.compiler
 			if req.body?.draft
 				options.draft = req.body.draft
-			if req.query?.isolated is "true"
-				options.isolated = true
 			logger.log {options:options, project_id:project_id, user_id:user_id}, "got compile request"
 			CompileManager.compile project_id, user_id, options, (error, status, outputFiles, clsiServerId, limits, validationProblems) ->
 				return next(error) if error?
@@ -44,17 +42,15 @@ module.exports = CompileController =
 				}
 
 	_compileAsUser: (req, callback) ->
-		# callback with user_id if isolated flag is set on request, undefined otherwise
-		isolated = req.query?.isolated is "true"
-		if isolated
+		# callback with user_id if per-user, undefined otherwise
+		if not Settings.disablePerUserCompiles
 			AuthenticationController.getLoggedInUserId req, callback # -> (error, user_id)
 		else
 			callback() # do a per-project compile, not per-user
 
 	_downloadAsUser: (req, callback) ->
-		# callback with user_id if isolated flag or user_id param is set on request, undefined otherwise
-		isolated = req.query?.isolated is "true" or req.params.user_id?
-		if isolated
+		# callback with user_id if per-user, undefined otherwise
+		if not Settings.disablePerUserCompiles
 			AuthenticationController.getLoggedInUserId req, callback # -> (error, user_id)
 		else
 			callback() # do a per-project compile, not per-user

--- a/app/coffee/Features/Compile/CompileManager.coffee
+++ b/app/coffee/Features/Compile/CompileManager.coffee
@@ -38,7 +38,7 @@ module.exports = CompileManager =
 							for key, value of limits
 								options[key] = value
 							# only pass user_id down to clsi if this is a per-user compile
-							compileAsUser = if options.isolated then user_id else undefined
+							compileAsUser = if Settings.disablePerUserCompiles then undefined else user_id
 							ClsiManager.sendRequest project_id, compileAsUser, options, (error, status, outputFiles, clsiServerId, validationProblems) ->
 								return callback(error) if error?
 								logger.log files: outputFiles, "output files"

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -262,6 +262,10 @@ module.exports = settings =
 	# Should we allow access to any page without logging in? This includes
 	# public projects, /learn, /templates, about pages, etc.
 	allowPublicAccess: if process.env["SHARELATEX_ALLOW_PUBLIC_ACCESS"] == 'true' then true else false
+
+	# Use a single compile directory for all users in a project
+	# (otherwise each user has their own directory)
+	disablePerUserCompiles: true
 	
 	# Maximum size of text documents in the real-time editing system.
 	max_doc_length: 2 * 1024 * 1024 # 2mb

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -265,7 +265,7 @@ module.exports = settings =
 
 	# Use a single compile directory for all users in a project
 	# (otherwise each user has their own directory)
-	disablePerUserCompiles: true
+	# disablePerUserCompiles: true
 	
 	# Maximum size of text documents in the real-time editing system.
 	max_doc_length: 2 * 1024 * 1024 # 2mb

--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -50,8 +50,6 @@ define [
 			params = {}
 			if options.isAutoCompile
 				params["auto_compile"]=true
-			if perUserCompile # send ?isolated=true for per-user compiles
-				params["isolated"] = true
 			return $http.post url, {
 				rootDoc_id: options.rootDocOverride_id or null
 				draft: $scope.draft
@@ -125,9 +123,6 @@ define [
 				# convert the qs hash into a query string and append it
 				$scope.pdf.qs = createQueryString qs
 				$scope.pdf.url += $scope.pdf.qs
-				# special case for the download url
-				if perUserCompile
-					qs.isolated = true
 				# Save all downloads as files
 				qs.popupDownload = true
 				$scope.pdf.downloadUrl = "/project/#{$scope.project_id}/output/output.pdf" + createQueryString(qs)
@@ -147,8 +142,6 @@ define [
 					else
 						file.name = file.path
 					qs = {}
-					if perUserCompile
-						qs.isolated = true
 					if response.clsiServerId?
 						qs.clsiserverid = response.clsiServerId
 					file.url = "/project/#{project_id}/output/#{file.path}" +	createQueryString qs
@@ -274,7 +267,6 @@ define [
 				method: "DELETE"
 				params:
 					clsiserverid:ide.clsiServerId
-					isolated: perUserCompile
 				headers:
 					"X-Csrf-Token": window.csrfToken
 			}
@@ -361,7 +353,6 @@ define [
 							line: row + 1
 							column: column
 							clsiserverid:ide.clsiServerId
-							isolated: perUserCompile
 						}
 					})
 					.success (data) ->
@@ -407,7 +398,6 @@ define [
 							h: h.toFixed(2)
 							v: v.toFixed(2)
 							clsiserverid:ide.clsiServerId
-							isolated: perUserCompile
 						}
 					})
 					.success (data) ->

--- a/public/coffee/ide/wordcount/controllers/WordCountModalController.coffee
+++ b/public/coffee/ide/wordcount/controllers/WordCountModalController.coffee
@@ -5,15 +5,11 @@ define [
 		$scope.status = 
 			loading:true
 
-		# enable per-user containers by default
-		perUserCompile = true
-
 		opts =
 			url:"/project/#{ide.project_id}/wordcount"
 			method:"GET"
 			params:
 				clsiserverid:ide.clsiServerId
-				isolated: perUserCompile
 		$http opts
 			.success (data) ->
 				$scope.status.loading = false

--- a/test/UnitTests/coffee/Compile/CompileControllerTests.coffee
+++ b/test/UnitTests/coffee/Compile/CompileControllerTests.coffee
@@ -139,7 +139,7 @@ describe "CompileController", ->
 					.should.equal true
 
 			it "should proxy the PDF from the CLSI", ->
-				@CompileController.proxyToClsi.calledWith(@project_id, "/project/#{@project_id}/output/output.pdf", @req, @res, @next).should.equal true
+				@CompileController.proxyToClsi.calledWith(@project_id, "/project/#{@project_id}/user/#{@user_id}/output/output.pdf", @req, @res, @next).should.equal true
 
 		describe "when the pdf is not going to be used in pdfjs viewer", ->
 
@@ -338,8 +338,6 @@ describe "CompileController", ->
 			@req =
 				params:
 					project_id:@project_id
-				query:
-					isolated: "true"
 			@CompileManager.compile.callsArgWith(3)
 			@CompileController.proxyToClsi = sinon.stub()
 			@res = 
@@ -362,8 +360,6 @@ describe "CompileController", ->
 			@CompileManager.wordCount = sinon.stub().callsArgWith(3, null, {content:"body"})
 			@req.params =
 				Project_id: @project_id
-			@req.query =
-				isolated: "true"
 			@res.send = sinon.stub()
 			@res.contentType = sinon.stub()
 			@CompileController.wordCount @req, @res, @next

--- a/test/UnitTests/coffee/Compile/CompileManagerTests.coffee
+++ b/test/UnitTests/coffee/Compile/CompileManagerTests.coffee
@@ -71,7 +71,7 @@ describe "CompileManager", ->
 
 			it "should run the compile with the compile limits", ->
 				@ClsiManager.sendRequest
-					.calledWith(@project_id, undefined, {
+					.calledWith(@project_id, @user_id, {
 						timeout: @limits.timeout
 					})
 					.should.equal true


### PR DESCRIPTION
don't require the client to send ?isolated=true

can override with Settings.disablePerUserCompiles:true