### PR TITLE
Countly pruning

### DIFF
--- a/app/views/layout.jade
+++ b/app/views/layout.jade
@@ -56,9 +56,6 @@ html(itemscope, itemtype='http://schema.org/Product')
 				Countly.url = '#{settings.analytics.countly.server}';
 				!{ session.user ? 'Countly.device_id = "' + session.user._id + '";' : '' } 
 
-				Countly.q.push(['track_sessions']);
-				Countly.q.push(['track_pageview']);
-
 				(function() {
 					var cly = document.createElement('script'); cly.type = 'text/javascript';
 					cly.async = true;

--- a/public/coffee/ide.coffee
+++ b/public/coffee/ide.coffee
@@ -72,13 +72,13 @@ define [
 		# Tracking code.
 		$scope.$watch "ui.view", (newView, oldView) ->
 			if newView? and newView != "editor" and newView != "pdf"
-				event_tracking.sendCountly "ide-open-view-#{ newView }" 
+				event_tracking.sendCountlyOnce "ide-open-view-#{ newView }" 
 
 		$scope.$watch "ui.chatOpen", (isOpen) ->
-			event_tracking.sendCountly "ide-open-chat" if isOpen
+			event_tracking.sendCountlyOnce "ide-open-chat" if isOpen
 
 		$scope.$watch "ui.leftMenuShown", (isOpen) ->
-			event_tracking.sendCountly "ide-open-left-menu" if isOpen
+			event_tracking.sendCountlyOnce "ide-open-left-menu" if isOpen
 		# End of tracking code.
 
 		window._ide = ide

--- a/public/coffee/ide.coffee
+++ b/public/coffee/ide.coffee
@@ -72,13 +72,13 @@ define [
 		# Tracking code.
 		$scope.$watch "ui.view", (newView, oldView) ->
 			if newView? and newView != "editor" and newView != "pdf"
-				event_tracking.sendCountlyOnce "ide-open-view-#{ newView }" 
+				event_tracking.sendCountlyOnce "ide-open-view-#{ newView }-once" 
 
 		$scope.$watch "ui.chatOpen", (isOpen) ->
-			event_tracking.sendCountlyOnce "ide-open-chat" if isOpen
+			event_tracking.sendCountlyOnce "ide-open-chat-once" if isOpen
 
 		$scope.$watch "ui.leftMenuShown", (isOpen) ->
-			event_tracking.sendCountlyOnce "ide-open-left-menu" if isOpen
+			event_tracking.sendCountlyOnce "ide-open-left-menu-once" if isOpen
 		# End of tracking code.
 
 		window._ide = ide

--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -333,7 +333,7 @@ define [
 
 		$scope.toggleLogs = () ->
 			$scope.shouldShowLogs = !$scope.shouldShowLogs
-			event_tracking.sendCountly "ide-open-logs" if $scope.shouldShowLogs
+			event_tracking.sendCountlyOnce "ide-open-logs" if $scope.shouldShowLogs
 
 		$scope.showPdf = () ->
 			$scope.pdf.view = "pdf"
@@ -499,7 +499,7 @@ define [
 
 	App.controller "PdfLogEntryController", ["$scope", "ide", "event_tracking", ($scope, ide, event_tracking) ->
 		$scope.openInEditor = (entry) ->
-			event_tracking.sendCountly 'logs-jump-to-location'
+			event_tracking.sendCountlyOnce 'logs-jump-to-location'
 			entity = ide.fileTreeManager.findEntityByPath(entry.file)
 			return if !entity? or entity.type != "doc"
 			if entry.line?

--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -333,7 +333,7 @@ define [
 
 		$scope.toggleLogs = () ->
 			$scope.shouldShowLogs = !$scope.shouldShowLogs
-			event_tracking.sendCountlyOnce "ide-open-logs" if $scope.shouldShowLogs
+			event_tracking.sendCountlyOnce "ide-open-logs-once" if $scope.shouldShowLogs
 
 		$scope.showPdf = () ->
 			$scope.pdf.view = "pdf"
@@ -499,7 +499,7 @@ define [
 
 	App.controller "PdfLogEntryController", ["$scope", "ide", "event_tracking", ($scope, ide, event_tracking) ->
 		$scope.openInEditor = (entry) ->
-			event_tracking.sendCountlyOnce 'logs-jump-to-location'
+			event_tracking.sendCountlyOnce "logs-jump-to-location-once"
 			entity = ide.fileTreeManager.findEntityByPath(entry.file)
 			return if !entity? or entity.type != "doc"
 			if entry.line?

--- a/public/coffee/ide/share/controllers/ShareController.coffee
+++ b/public/coffee/ide/share/controllers/ShareController.coffee
@@ -3,7 +3,7 @@ define [
 ], (App) ->
 	App.controller "ShareController", ["$scope", "$modal", "event_tracking", ($scope, $modal, event_tracking) ->
 		$scope.openShareProjectModal = () ->
-			event_tracking.sendCountly "ide-open-share-modal"
+			event_tracking.sendCountlyOnce "ide-open-share-modal"
 
 			$modal.open(
 				templateUrl: "shareProjectModalTemplate"

--- a/public/coffee/ide/share/controllers/ShareController.coffee
+++ b/public/coffee/ide/share/controllers/ShareController.coffee
@@ -3,7 +3,7 @@ define [
 ], (App) ->
 	App.controller "ShareController", ["$scope", "$modal", "event_tracking", ($scope, $modal, event_tracking) ->
 		$scope.openShareProjectModal = () ->
-			event_tracking.sendCountlyOnce "ide-open-share-modal"
+			event_tracking.sendCountlyOnce "ide-open-share-modal-once"
 
 			$modal.open(
 				templateUrl: "shareProjectModalTemplate"

--- a/public/coffee/main/event.coffee
+++ b/public/coffee/main/event.coffee
@@ -17,11 +17,7 @@ define [
 
 		_eventInCache = (key) ->
 			curCache = _getEventCache()
-
-			if (curCache.hasOwnProperty key) 
-				curCache[key]
-			else
-				false
+			curCache[key] || false
 
 		_addEventToCache = (key) ->
 			curCache = _getEventCache()

--- a/public/coffee/main/event.coffee
+++ b/public/coffee/main/event.coffee
@@ -21,7 +21,7 @@ define [
 		curCache = _getEventCache()
 
 		if (curCache.hasOwnProperty key) 
-			_getEventCache()[key]
+			curCache[key]
 		else
 			false
 
@@ -36,7 +36,6 @@ define [
 
 
 	App.factory "event_tracking", ->
-
 		return {
 			send: (category, action, label, value)->
 				ga('send', 'event', category, action, label, value)

--- a/public/coffee/main/event.coffee
+++ b/public/coffee/main/event.coffee
@@ -4,14 +4,18 @@ define [
 	CACHE_KEY = "countlyEvents"
 
 	_getEventCache = () -> 
-		eventCache = window.localStorage.getItem CACHE_KEY
+		eventCacheStr = window.localStorage.getItem CACHE_KEY
 
 		# Initialize as an empy object if the event cache is still empty.
-		if !eventCache?
-			window.localStorage.setItem(CACHE_KEY, "{}")
-			eventCache = window.localStorage.getItem CACHE_KEY
+		if !eventCacheStr?
+			eventCacheStr = "{}"
 
-		return JSON.parse eventCache
+			# Errors writing to localStorage may happen when quota is full or
+			# browser is in incognito mode. We'll return an empty object, anyway.
+			try
+				window.localStorage.setItem CACHE_KEY, eventCacheStr 
+
+		return JSON.parse eventCacheStr
 
 	_eventInCache = (key) ->
 		curCache = _getEventCache()
@@ -25,7 +29,11 @@ define [
 		curCache = _getEventCache()
 		curCache[key] = true
 		curCacheAsStr  = JSON.stringify curCache
-		window.localStorage.setItem CACHE_KEY, curCacheAsStr
+
+		# Protection against issues mentioned above.
+		try
+			window.localStorage.setItem CACHE_KEY, curCacheAsStr
+
 
 	App.factory "event_tracking", ->
 


### PR DESCRIPTION
Diminish the amount of data being sent to Countly:

- Don't track page views
- Don't track sessions
- Track a few events only the first time they happen for a given user (we only want to know it happened once, not the amount/frequency).