### PR TITLE
Workaround for safari scrolling bug

### DIFF
--- a/public/coffee/ide.coffee
+++ b/public/coffee/ide.coffee
@@ -138,7 +138,7 @@ define [
 			console.error err
 
 		if ide.browserIsSafari
-			ide.safariScrollPatcher = new SafariScrollPatcher(ide, $scope)
+			ide.safariScrollPatcher = new SafariScrollPatcher($scope)
 
 		# User can append ?ft=somefeature to url to activate a feature toggle
 		ide.featureToggle = location?.search?.match(/^\?ft=(\w+)$/)?[1]

--- a/public/coffee/ide.coffee
+++ b/public/coffee/ide.coffee
@@ -9,6 +9,7 @@ define [
 	"ide/pdf/PdfManager"
 	"ide/binary-files/BinaryFilesManager"
 	"ide/references/ReferencesManager"
+	"ide/SafariScrollPatcher"
 	"ide/settings/index"
 	"ide/share/index"
 	"ide/chat/index"
@@ -40,6 +41,7 @@ define [
 	PdfManager
 	BinaryFilesManager
 	ReferencesManager
+	SafariScrollPatcher
 ) ->
 
 	App.controller "IdeController", ($scope, $timeout, ide, localStorage, event_tracking) ->
@@ -134,6 +136,9 @@ define [
 			)
 		catch err
 			console.error err
+
+		if ide.browserIsSafari
+			ide.safariScrollPatcher = new SafariScrollPatcher(ide, $scope)
 
 		# User can append ?ft=somefeature to url to activate a feature toggle
 		ide.featureToggle = location?.search?.match(/^\?ft=(\w+)$/)?[1]

--- a/public/coffee/ide/SafariScrollPatcher.coffee
+++ b/public/coffee/ide/SafariScrollPatcher.coffee
@@ -2,58 +2,79 @@ define [
 ], () ->
 	class SafariScrollPatcher
 		constructor: (ide, $scope) ->
-			@isBootstrapped = false
-			@isOverAce = false
+			@isOverAce = false # Flag to control if the pointer is over Ace.
 			@pdfDiv = null
 			@aceDiv = null
 
+			# Start listening to PDF wheel events when the pointer leaves the PDF region.
+			# P.S. This is the problem in a nutshell: although the pointer is elsewhere,
+			# wheel events keep being dispatched to the PDF.
+			@handlePdfDivMouseLeave = () =>
+				console.log "dispatching to ace enabled"
+				@pdfDiv.addEventListener "wheel", @dispatchToAce
+
+			# Stop listening to wheel events when the pointer enters the PDF region. If 
+			# the pointer is over the PDF, native behaviour is adequate. 
+			@handlePdfDivMouseEnter = () =>
+				console.log "dispatching to ace disabled"
+				@pdfDiv.removeEventListener "wheel", @dispatchToAce
+
+			# Set the "pointer over Ace" flag as false, when the mouse leaves its area.
+			@handleAceDivMouseLeave = () =>
+				@isOverAce = false
+				console.log 'is over ace = ' + @isOverAce
+
+			# Set the "pointer over Ace" flag as true, when the mouse enters its area.
+			@handleAceDivMouseEnter = () =>
+				@isOverAce = true
+				console.log 'is over ace = ' + @isOverAce
+
+			# Grab the elements (pdfDiv, aceDiv) and set the "hover" event listeners.
+			# If elements are already defined, clear existing event listeners and do
+			# the process again (grab elements, set listeners).	
+			@setListeners = () =>
+				@isOverAce = false
+
+				# If elements aren't null, remove existing listeners.
+				if @pdfDiv?
+					@pdfDiv.removeEventListener @handlePdfDivMouseLeave
+					@pdfDiv.removeEventListener @handlePdfDivMouseEnter
+
+				if @aceDiv?
+					@aceDiv.removeEventListener @handleAceDivMouseLeave
+					@aceDiv.removeEventListener @handleAceDivMouseEnter
+
+				# Grab elements.
+				@pdfDiv = document.querySelector ".pdfjs-viewer"	# Grab the PDF div.
+				@aceDiv = document.querySelector ".ace_content"	# Also the editor.
+
+				# Set hover-related listeners.
+				@pdfDiv.addEventListener "mouseleave", @handlePdfDivMouseLeave
+				@pdfDiv.addEventListener "mouseenter", @handlePdfDivMouseEnter
+				@aceDiv.addEventListener "mouseleave", @handleAceDivMouseLeave
+				@aceDiv.addEventListener "mouseenter", @handleAceDivMouseEnter
+
+			# Handler for wheel events on the PDF.
+			# If the pointer is over Ace, grab the event, prevent default behaviour
+			# and dispatch it to Ace.
+			@dispatchToAce = (e) =>
+				if @isOverAce
+					# If this is logged, the problem just happened: the event arrived
+					# here (the PDF wheel handler), but it should've gone to Ace.
+					console.log "Event was bound to the PDF, dispatching to Ace"
+
+					# Small timeout - if we dispatch immediately, an exception is thrown.
+					window.setTimeout(() =>
+						# Dispatch the exact same event to Ace (this will keep values
+						# values e.g. `wheelDelta` consistent with user interaction).
+						@aceDiv.dispatchEvent e
+					, 5)
+
+					# Avoid scrolling the PDF, as we assume this was intended to the 
+					# editor.
+					e.preventDefault()
+
 			$scope.$on "loaded", () =>
-				console.log this
-				if !@isBootstrapped
-					console.log "bootstrapping"
-
-					@isBootstrapped = true;
-					@pdfDiv = document.querySelector ".pdfjs-viewer"	# Grab the PDF div.
-					@aceDiv = document.querySelector ".ace_content"	# Also the editor.
-					@isOverAce = false # Flag to control if the pointer is over Ace.
-
-					# Start listening to PDF wheel events when the pointer leaves the PDF region.
-					# P.S. This is the problem in a nutshell: although the pointer is elsewhere,
-					# wheel events keep being dispatched to the PDF.
-					@pdfDiv.addEventListener "mouseleave", () => 
-						@pdfDiv.addEventListener "wheel", dispatchToAce
-
-					# Stop listening to wheel events when the pointer enters the PDF region. If 
-					# the pointer is over the PDF, native behaviour is adequate. 
-					@pdfDiv.addEventListener "mouseenter", () => 
-						@pdfDiv.removeEventListener "wheel", dispatchToAce
-
-					# Set the "pointer over Ace" flag as false, when the mouse leaves its area.
-					@aceDiv.addEventListener "mouseleave", () => 
-						@isOverAce = false
-
-					# Set the "pointer over Ace" flag as true, when the mouse enters its area.
-					@aceDiv.addEventListener "mouseenter", () => 
-						@isOverAce = true
-
-					# Handler for wheel events on the PDF.
-					# If the pointer is over Ace, grab the event, prevent default behaviour
-					# and dispatch it to Ace.
-					dispatchToAce = (e) =>
-						if @isOverAce
-							# If this is logged, the problem just happened: the event arrived
-							# here (the PDF wheel handler), but it should've gone to Ace.
-							console.log "Event was bound to the PDF, dispatching to Ace"
-
-							# Small timeout - if we dispatch immediately, an exception is thrown.
-							window.setTimeout(() =>
-								# Dispatch the exact same event to Ace (this will keep values
-								# values e.g. `wheelDelta` consistent with user interaction).
-								@aceDiv.dispatchEvent e
-							, 5)
-
-							# Avoid scrolling the PDF, as we assume this was intended to the 
-							# editor.
-							e.preventDefault()
+				@setListeners()
 
 

--- a/public/coffee/ide/SafariScrollPatcher.coffee
+++ b/public/coffee/ide/SafariScrollPatcher.coffee
@@ -1,0 +1,59 @@
+define [
+], () ->
+	class SafariScrollPatcher
+		constructor: (ide, $scope) ->
+			@isBootstrapped = false
+			@isOverAce = false
+			@pdfDiv = null
+			@aceDiv = null
+
+			$scope.$on "loaded", () =>
+				console.log this
+				if !@isBootstrapped
+					console.log "bootstrapping"
+
+					@isBootstrapped = true;
+					@pdfDiv = document.querySelector ".pdfjs-viewer"	# Grab the PDF div.
+					@aceDiv = document.querySelector ".ace_content"	# Also the editor.
+					@isOverAce = false # Flag to control if the pointer is over Ace.
+
+					# Start listening to PDF wheel events when the pointer leaves the PDF region.
+					# P.S. This is the problem in a nutshell: although the pointer is elsewhere,
+					# wheel events keep being dispatched to the PDF.
+					@pdfDiv.addEventListener "mouseleave", () => 
+						@pdfDiv.addEventListener "wheel", dispatchToAce
+
+					# Stop listening to wheel events when the pointer enters the PDF region. If 
+					# the pointer is over the PDF, native behaviour is adequate. 
+					@pdfDiv.addEventListener "mouseenter", () => 
+						@pdfDiv.removeEventListener "wheel", dispatchToAce
+
+					# Set the "pointer over Ace" flag as false, when the mouse leaves its area.
+					@aceDiv.addEventListener "mouseleave", () => 
+						@isOverAce = false
+
+					# Set the "pointer over Ace" flag as true, when the mouse enters its area.
+					@aceDiv.addEventListener "mouseenter", () => 
+						@isOverAce = true
+
+					# Handler for wheel events on the PDF.
+					# If the pointer is over Ace, grab the event, prevent default behaviour
+					# and dispatch it to Ace.
+					dispatchToAce = (e) =>
+						if @isOverAce
+							# If this is logged, the problem just happened: the event arrived
+							# here (the PDF wheel handler), but it should've gone to Ace.
+							console.log "Event was bound to the PDF, dispatching to Ace"
+
+							# Small timeout - if we dispatch immediately, an exception is thrown.
+							window.setTimeout(() =>
+								# Dispatch the exact same event to Ace (this will keep values
+								# values e.g. `wheelDelta` consistent with user interaction).
+								@aceDiv.dispatchEvent e
+							, 5)
+
+							# Avoid scrolling the PDF, as we assume this was intended to the 
+							# editor.
+							e.preventDefault()
+
+

--- a/public/coffee/ide/SafariScrollPatcher.coffee
+++ b/public/coffee/ide/SafariScrollPatcher.coffee
@@ -69,6 +69,9 @@ define [
 					# editor.
 					e.preventDefault()
 
+			# "loaded" event is emitted from the pdfViewer controller $scope. This means
+			# that the previous PDF DOM element was destroyed and a new one is available,
+			# so we need to grab the elements and set the listeners again.
 			$scope.$on "loaded", () =>
 				@setListeners()
 

--- a/public/coffee/ide/SafariScrollPatcher.coffee
+++ b/public/coffee/ide/SafariScrollPatcher.coffee
@@ -1,7 +1,7 @@
 define [
 ], () ->
 	class SafariScrollPatcher
-		constructor: (ide, $scope) ->
+		constructor: ($scope) ->
 			@isOverAce = false # Flag to control if the pointer is over Ace.
 			@pdfDiv = null
 			@aceDiv = null
@@ -10,24 +10,20 @@ define [
 			# P.S. This is the problem in a nutshell: although the pointer is elsewhere,
 			# wheel events keep being dispatched to the PDF.
 			@handlePdfDivMouseLeave = () =>
-				console.log "dispatching to ace enabled"
 				@pdfDiv.addEventListener "wheel", @dispatchToAce
 
 			# Stop listening to wheel events when the pointer enters the PDF region. If 
 			# the pointer is over the PDF, native behaviour is adequate. 
 			@handlePdfDivMouseEnter = () =>
-				console.log "dispatching to ace disabled"
 				@pdfDiv.removeEventListener "wheel", @dispatchToAce
 
 			# Set the "pointer over Ace" flag as false, when the mouse leaves its area.
 			@handleAceDivMouseLeave = () =>
 				@isOverAce = false
-				console.log 'is over ace = ' + @isOverAce
 
 			# Set the "pointer over Ace" flag as true, when the mouse enters its area.
 			@handleAceDivMouseEnter = () =>
 				@isOverAce = true
-				console.log 'is over ace = ' + @isOverAce
 
 			# Grab the elements (pdfDiv, aceDiv) and set the "hover" event listeners.
 			# If elements are already defined, clear existing event listeners and do
@@ -46,7 +42,7 @@ define [
 
 				# Grab elements.
 				@pdfDiv = document.querySelector ".pdfjs-viewer"	# Grab the PDF div.
-				@aceDiv = document.querySelector ".ace_content"	# Also the editor.
+				@aceDiv = document.querySelector ".ace_content"		# Also the editor.
 
 				# Set hover-related listeners.
 				@pdfDiv.addEventListener "mouseleave", @handlePdfDivMouseLeave
@@ -61,14 +57,13 @@ define [
 				if @isOverAce
 					# If this is logged, the problem just happened: the event arrived
 					# here (the PDF wheel handler), but it should've gone to Ace.
-					console.log "Event was bound to the PDF, dispatching to Ace"
 
 					# Small timeout - if we dispatch immediately, an exception is thrown.
 					window.setTimeout(() =>
 						# Dispatch the exact same event to Ace (this will keep values
 						# values e.g. `wheelDelta` consistent with user interaction).
 						@aceDiv.dispatchEvent e
-					, 5)
+					, 1)
 
 					# Avoid scrolling the PDF, as we assume this was intended to the 
 					# editor.


### PR DESCRIPTION
This PR adds a workaround for the misplaced scroll behaviour (in Safari).

Problem: scroll (`wheel`) events were being sent to the PDF preview (built-in), while the mouse pointer was hovering the editor. Something is causing Safari to miscalculate each element's region.

Solution: listen to `wheel` events bound to the PDF preview while the mouse is *not* hovering it, then dispatch it to the editor (if it's being hovered).