### PR TITLE
Hide "sign up" button in plans page, if user is logged in

### DIFF
--- a/app/views/subscriptions/plans.jade
+++ b/app/views/subscriptions/plans.jade
@@ -139,7 +139,10 @@ block content
 											li &nbsp;
 											li
 												br
-												a.btn.btn-info(href="/register") #{translate("sign_up_now")}
+												a.btn.btn-info(
+													href="/register"
+													style=(getLoggedInUserId() === undefined ? "" : "visibility: hidden")
+												) #{translate("sign_up_now")}
 								
 								.col-md-4
 									.card.card-highlighted

--- a/app/views/subscriptions/plans.jade
+++ b/app/views/subscriptions/plans.jade
@@ -72,7 +72,10 @@ block content
 											li &nbsp;
 											li
 												br
-												a.btn.btn-info(href="/register") #{translate("sign_up_now")}
+												a.btn.btn-info(
+													href="/register"
+													style=(getLoggedInUserId() === undefined ? "" : "visibility: hidden")
+												) #{translate("sign_up_now")}
 								.col-md-4
 									.card.card-highlighted
 										.card-header


### PR DESCRIPTION
Hide sign up button via CSS visibility (to keep the layout sizing), if the user is logged in.