### PR TITLE
clean up compile check

### DIFF
--- a/app/coffee/Features/Compile/ClsiCookieManager.coffee
+++ b/app/coffee/Features/Compile/ClsiCookieManager.coffee
@@ -48,6 +48,10 @@ module.exports = ClsiCookieManager =
 		multi.exec (err)->
 			callback(err, serverId)
 
+	clearServerId: (project_id, callback = (err)->)->
+		if !clsiCookiesEnabled
+			return callback()
+		rclient.del buildKey(project_id), callback
 
 	getCookieJar: (project_id, callback = (err, jar)->)->
 		if !clsiCookiesEnabled

--- a/app/coffee/router.coffee
+++ b/app/coffee/router.coffee
@@ -252,13 +252,24 @@ module.exports = class Router
 
 		apiRouter.get "/status/compiler/:Project_id", AuthorizationMiddlewear.ensureUserCanReadProject, (req, res) ->
 			sendRes = _.once (statusCode, message)->
-				res.writeHead statusCode
-				res.end message
-			CompileManager.compile req.params.Project_id, "test-compile", {}, () ->
-				sendRes 200, "Compiler returned in less than 10 seconds"
-			setTimeout (() ->
+				res.status statusCode
+				res.send message
+			# set a timeout
+			handler = setTimeout (() ->
 				sendRes 500, "Compiler timed out"
+				handler = null
 			), 10000
+			# use a valid user id for testing
+			test_user_id = "123456789012345678901234"
+			# run the compile
+			CompileManager.compile req.params.Project_id, test_user_id, {}, (error, status) ->
+				clearTimeout handler if handler?
+				if error?
+					sendRes 500, "Compiler returned error #{error.message}"
+				else if status is "success"
+					sendRes 200, "Compiler returned in less than 10 seconds"
+				else
+					sendRes 500, "Compiler returned failure #{status}"
 
 		apiRouter.get "/ip", (req, res, next) ->
 			res.send({


### PR DESCRIPTION
use a valid user id, report all failures as errors, clear timeout on success