### PR TITLE
use ace mode detection

### DIFF
--- a/app/views/project/editor/editor.jade
+++ b/app/views/project/editor/editor.jade
@@ -35,7 +35,8 @@ div.full-size(
 			resize-on="layout:main:resize,layout:pdf:resize",
 			annotations="pdf.logEntryAnnotations[editor.open_doc_id]",
 			read-only="!permissions.write",
-			on-ctrl-enter="recompileViaKey"
+			file-name="editor.open_doc_name",
+			on-ctrl-enter="recompileViaKey",
 			syntax-validation="settings.syntaxValidation"
 		)
 

--- a/public/coffee/ide/editor/EditorManager.coffee
+++ b/public/coffee/ide/editor/EditorManager.coffee
@@ -8,6 +8,7 @@ define [
 			@$scope.editor = {
 				sharejs_doc: null
 				open_doc_id: null
+				open_doc_name: null
 				opening: true
 			}
 
@@ -59,6 +60,7 @@ define [
 				return
 
 			@$scope.editor.open_doc_id = doc.id
+			@$scope.editor.open_doc_name = doc.name
 
 			@ide.localStorage "doc.open_id.#{@$scope.project_id}", doc.id
 			@ide.fileTreeManager.selectEntity(doc)

--- a/public/coffee/ide/editor/directives/aceEditor.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor.coffee
@@ -2,14 +2,16 @@ define [
 	"base"
 	"ace/ace"
 	"ace/ext-searchbox"
+	"ace/ext-modelist"
 	"ide/editor/directives/aceEditor/undo/UndoManager"
 	"ide/editor/directives/aceEditor/auto-complete/AutoCompleteManager"
 	"ide/editor/directives/aceEditor/spell-check/SpellCheckManager"
 	"ide/editor/directives/aceEditor/highlights/HighlightsManager"
 	"ide/editor/directives/aceEditor/cursor-position/CursorPositionManager"
 	"ide/editor/directives/aceEditor/track-changes/TrackChangesManager"
-], (App, Ace, SearchBox, UndoManager, AutoCompleteManager, SpellCheckManager, HighlightsManager, CursorPositionManager, TrackChangesManager) ->
+], (App, Ace, SearchBox, ModeList, UndoManager, AutoCompleteManager, SpellCheckManager, HighlightsManager, CursorPositionManager, TrackChangesManager) ->
 	EditSession = ace.require('ace/edit_session').EditSession
+	ModeList = ace.require('ace/ext/modelist')
 
 	# set the path for ace workers if using a CDN (from editor.jade)
 	if window.aceWorkerPath != ""
@@ -42,7 +44,8 @@ define [
 				text: "="
 				readOnly: "="
 				annotations: "="
-				navigateHighlights: "=",
+				navigateHighlights: "="
+				fileName: "="
 				onCtrlEnter: "="
 				syntaxValidation: "="
 			}
@@ -221,8 +224,16 @@ define [
 					session = editor.getSession()
 					if session?
 						session.destroy()
-					editor.setSession(new EditSession(lines, "ace/mode/latex"))
-					resetSession()
+
+					# see if we can lookup a suitable mode from ace
+					# but fall back to text by default
+					try
+						mode = ModeList.getModeForPath(scope.fileName).mode
+					catch
+						mode = "ace/mode/text"
+
+					editor.setSession(new EditSession(lines, mode))
+
 					session = editor.getSession()
 
 					doc = session.getDocument()

--- a/public/coffee/ide/editor/directives/aceEditor.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor.coffee
@@ -207,11 +207,6 @@ define [
 
 				editor.setOption("scrollPastEnd", true)
 
-				resetSession = () ->
-					session = editor.getSession()
-					session.setUseWrapMode(true)
-					session.setMode("ace/mode/latex")
-
 				updateCount = 0
 				onChange = () ->
 					updateCount++
@@ -235,6 +230,7 @@ define [
 					editor.setSession(new EditSession(lines, mode))
 
 					session = editor.getSession()
+					session.setUseWrapMode(true)
 
 					doc = session.getDocument()
 					doc.on "change", onChange


### PR DESCRIPTION
Ace has an extension for detecting modes from filenames.  We can use it to get full support for all file types.

Also, the mode only needs to be set once when the session is created.  This avoids unnecessary work as setting the mode multiple times can create a worker each time, even when one already exists.