### PR TITLE
rate limit on reconnects

### DIFF
--- a/public/coffee/ide/connection/ConnectionManager.coffee
+++ b/public/coffee/ide/connection/ConnectionManager.coffee
@@ -192,10 +192,16 @@ define [], () ->
 			, 200)
 
 		cancelReconnect: () ->
-			clearTimeout @timeoutId if @timeoutId?
-					
+			# clear timeout and set to null so we know there is no countdown running
+			if @timeoutId?
+				sl_console.log "[ConnectionManager] cancelling existing reconnect timer"
+				clearTimeout @timeoutId
+				@timeoutId = null
+
 		decreaseCountdown: () ->
+			@timeoutId = null
 			return if !@$scope.connection.reconnection_countdown?
+			sl_console.log "[ConnectionManager] decreasing countdown", @$scope.connection.reconnection_countdown
 			@$scope.$apply () =>
 				@$scope.connection.reconnection_countdown--
 

--- a/public/coffee/ide/connection/ConnectionManager.coffee
+++ b/public/coffee/ide/connection/ConnectionManager.coffee
@@ -28,8 +28,8 @@ define [], () ->
 			@connected = false
 			@userIsInactive = false
 			@gracefullyReconnecting = false
-			
-			@$scope.connection = 
+
+			@$scope.connection =
 				reconnecting: false
 				# If we need to force everyone to reload the editor
 				forced_disconnect: false
@@ -262,7 +262,7 @@ define [], () ->
 				setTimeout () =>
 					@reconnectGracefully()
 				, @RECONNECT_GRACEFULLY_RETRY_INTERVAL
-		
+
 		_reconnectGracefullyNow: () ->
 			@gracefullyReconnecting = true
 			@reconnectGracefullyStarted = null

--- a/public/coffee/ide/connection/ConnectionManager.coffee
+++ b/public/coffee/ide/connection/ConnectionManager.coffee
@@ -39,7 +39,7 @@ define [], () ->
 				@tryReconnect()
 
 			@$scope.$on 'cursor:editor:update', () =>
-				@lastUserAction = new Date()
+				@lastUserAction = new Date()  # time of last edit
 				if !@connected
 					@tryReconnect()
 
@@ -170,7 +170,7 @@ define [], () ->
 
 		startAutoReconnectCountdown: () ->
 			twoMinutes = 2 * 60 * 1000
-			if @lastUpdated? and new Date() - @lastUpdated > twoMinutes
+			if @lastUserAction? and new Date() - @lastUserAction > twoMinutes
 				# between 1 minute and 3 minutes
 				countdown = 60 + Math.floor(Math.random() * 120)
 			else

--- a/public/coffee/ide/connection/ConnectionManager.coffee
+++ b/public/coffee/ide/connection/ConnectionManager.coffee
@@ -169,9 +169,11 @@ define [], () ->
 			@tryReconnect()
 
 		disconnect: () ->
+			sl_console.log "[socket.io] disconnecting client"
 			@ide.socket.disconnect()
 
 		startAutoReconnectCountdown: () ->
+			sl_console.log "[ConnectionManager] starting autoreconnect countdown"
 			twoMinutes = 2 * 60 * 1000
 			if @lastUserAction? and new Date() - @lastUserAction > twoMinutes
 				# between 1 minute and 3 minutes
@@ -212,6 +214,7 @@ define [], () ->
 				@timeoutId = setTimeout (=> @decreaseCountdown()), 1000
 
 		tryReconnect: () ->
+			sl_console.log "[ConnectionManager] tryReconnect"
 			@cancelReconnect()
 			delete @$scope.connection.reconnection_countdown
 			return if @connected

--- a/public/coffee/ide/connection/ConnectionManager.coffee
+++ b/public/coffee/ide/connection/ConnectionManager.coffee
@@ -207,7 +207,9 @@ define [], () ->
 			delete @$scope.connection.reconnection_countdown
 			return if @connected
 			@$scope.connection.reconnecting = true
-			@ide.socket.socket.reconnect()
+			# use socket.io connect() here to make a single attempt, the
+			# reconnect() method makes multiple attempts
+			@ide.socket.socket.connect()
 			setTimeout (=> @startAutoReconnectCountdown() if !@connected), 2000
 
 		disconnectIfInactive: ()->


### PR DESCRIPTION
- fix change of lastUpdated to lastUserAction to correctly reduce connect rate after 2 minutes
- apply rate limit to reconnect attempts from cursor movement (fires rapidly)
- use socket.socket.connect() instead of socket.socket.reconnect() to avoid socket.io retrying in the background