### PR TITLE
Pass ignoreTLS option to nodemailer

### DIFF
--- a/app/coffee/Features/Email/EmailSender.coffee
+++ b/app/coffee/Features/Email/EmailSender.coffee
@@ -25,7 +25,7 @@ else if Settings?.email?.parameters?.sendgridApiKey?
 	logger.log "using sendgrid for email"
 	nm_client = nodemailer.createTransport(sgTransport({auth:{api_key:Settings?.email?.parameters?.sendgridApiKey}}))
 else if Settings?.email?.parameters?
-	smtp = _.pick(Settings?.email?.parameters, "host", "port", "secure", "auth")
+	smtp = _.pick(Settings?.email?.parameters, "host", "port", "secure", "auth", "ignoreTLS")
 
 
 	logger.log "using smtp for email"


### PR DESCRIPTION
This fixed a problem I was having with sending password reset emails via SMTP port 25 on a server that supports STARTTLS, but on which I did not want to use STARTTLS.

Without this change I would get a "CERT_UNTRUSTED" error, and nodemailer never sees the ignoreTLS option set in the environment.