### PR TITLE
lock editor when connection down

### DIFF
--- a/app/views/project/editor.jade
+++ b/app/views/project/editor.jade
@@ -85,6 +85,11 @@ block content
 		.modal-footer
 			button.btn.btn-info(ng-click="done()") #{translate("ok")}
 
+	script(type="text/ng-template", id="lockEditorModalTemplate")
+		.modal-header
+			h3 {{ title }}
+		.modal-body(ng-bind-html="message")
+
 block requirejs
 	script(type="text/javascript" src='/socket.io/socket.io.js')
 

--- a/public/coffee/ide/services/ide.coffee
+++ b/public/coffee/ide/services/ide.coffee
@@ -40,6 +40,19 @@ define [
 					message: -> message
 			}
 
+		ide.showLockEditorMessageModal = (title, message) ->
+			# modal to block the editor when connection is down
+			$modal.open {
+				templateUrl: "lockEditorModalTemplate"
+				controller:  "GenericMessageModalController"
+				backdrop:    "static" # prevent dismiss by click on background
+				keyboard:    false    # prevent dismiss via keyboard
+				resolve:
+					title:   -> title
+					message: -> message
+				windowClass: "lock-editor-modal"
+			}
+
 		return ide
 	]
 

--- a/public/stylesheets/app/editor.less
+++ b/public/stylesheets/app/editor.less
@@ -263,6 +263,16 @@
 	margin-bottom:0px;
 }
 
+// vertically centre the "connection down" modal so it does not hide
+// the reconnecting indicator
+
+.modal.lock-editor-modal {
+	display: flex !important;
+	.modal-dialog {
+		margin: auto;
+	}
+}
+
 .sl_references_search_hint-varDefault {
 	position: absolute;
 	bottom: -22px;


### PR DESCRIPTION
block access to the editor after 15 seconds of unsaved changes.

reconnect attempts continue in the background.