### PR TITLE
redirect to login on 403

### DIFF
--- a/app/views/project/editor/editor.jade
+++ b/app/views/project/editor/editor.jade
@@ -24,7 +24,7 @@ div.full-size(
 			keybindings="settings.mode",
 			font-size="settings.fontSize",
 			auto-complete="settings.autoComplete",
-			spell-check="true",
+			spell-check="!anonymous",
 			spell-check-language="project.spellCheckLanguage",
 			highlights="onlineUserCursorHighlights[editor.open_doc_id]"
 			show-print-margin="false",

--- a/public/coffee/directives/asyncForm.coffee
+++ b/public/coffee/directives/asyncForm.coffee
@@ -24,8 +24,10 @@ define [
 
 					scope[attrs.name].inflight = true
 
+					# for asyncForm prevent automatic redirect to /login if
+					# authentication fails, we will handle it ourselves
 					$http
-						.post(element.attr('action'), formData)
+						.post(element.attr('action'), formData, {disableAutoLoginRedirect: true})
 						.success (data, status, headers, config) ->
 							scope[attrs.name].inflight = false
 							response.success = true

--- a/public/coffee/main/account-settings.coffee
+++ b/public/coffee/main/account-settings.coffee
@@ -57,6 +57,7 @@ define [
 							"Content-Type": 'application/json'
 						data:
 							password: $scope.state.password
+						disableAutoLoginRedirect: true # we want to handle errors ourselves
 					})
 					.success () ->
 						$modalInstance.close()

--- a/public/coffee/modules/errorCatcher.coffee
+++ b/public/coffee/modules/errorCatcher.coffee
@@ -9,6 +9,26 @@ app.config ['$provide', ($provide) ->
 	]
 ]
 
-# TODO: add support for an errorHttpInterceptor to catch failing ajax
-# requests as described at
+# Interceptor to check auth failures in all $http requests
 # http://bahmutov.calepin.co/catch-all-errors-in-angular-app.html
+
+app.factory 'unAuthHttpResponseInterceptor', ['$q','$location', ($q, $location) ->
+		responseError: (response) ->
+			# redirect any unauthorised or forbidden responses back to /login
+			#
+			# set disableAutoLoginRedirect:true in the http request config
+			# to disable this behaviour
+			if response.status in [401, 403] and not response.config?.disableAutoLoginRedirect
+				# for /project urls set the ?redir parameter to come back here
+				# otherwise just go to the login page
+				if window.location.pathname.match(/^\/project/)
+					window.location = "/login?redir=#{encodeURI(window.location.pathname)}"
+				else
+					window.location = "/login"
+			# pass the response back to the original requester
+			return $q.reject(response)
+]
+
+app.config ['$httpProvider', ($httpProvider) ->
+	$httpProvider.interceptors.push 'unAuthHttpResponseInterceptor'
+]


### PR DESCRIPTION
if the user gets a 401 or 403 on any http request while using the editor we redirect them to /login

exceptions for asyncForm and delete account

also turn off spelling for anonymous users, because it always fails the auth check