### PR TITLE
Sk learn anchor links

### DIFF
--- a/public/coffee/main.coffee
+++ b/public/coffee/main.coffee
@@ -33,4 +33,18 @@ define [
 	"filters/formatDate"
 	"__MAIN_CLIENTSIDE_INCLUDES__"
 ], () ->
-	angular.bootstrap(document.body, ["SharelatexApp"])
+	angular.module('SharelatexApp').config(
+		($locationProvider) ->
+			try
+				$locationProvider.html5Mode({
+					enabled: true,
+					requireBase: false,
+					rewriteLinks: false
+				})
+			catch e
+				console.error "Error while trying to fix '#' links: ", e
+	)
+	angular.bootstrap(
+		document.body,
+		["SharelatexApp"]
+	)

--- a/public/coffee/main.coffee
+++ b/public/coffee/main.coffee
@@ -37,7 +37,7 @@ define [
 		($locationProvider) ->
 			try
 				$locationProvider.html5Mode({
-					enabled: true,
+					enabled: false,
 					requireBase: false,
 					rewriteLinks: false
 				})


### PR DESCRIPTION
Disable angular hijacking `#` links.

This specifically un-breaks the behaviour of `#` links in the learn pages.