### PR TITLE
Sk top menu rework

### DIFF
--- a/app/coffee/infrastructure/ExpressLocals.coffee
+++ b/app/coffee/infrastructure/ExpressLocals.coffee
@@ -244,17 +244,8 @@ module.exports = (app, webRouter, apiRouter)->
 		for key, value of Settings.nav
 			res.locals.nav[key] = _.clone(Settings.nav[key])
 		res.locals.templates = Settings.templateLinks
-		try
-			externalAuth = res.locals.externalAuthenticationSystemUsed()
-			if externalAuth and res.locals.nav.header?
-				# filter out '/register' link
-				res.locals.nav.header = _.filter(
-					res.locals.nav.header,
-					(h) ->
-						h.url != '/register'
-				)
-		catch error
-			logger.error {error}, "error while trying to filter out '/register' links from header"
+		if res.locals.nav.header
+			console.error {}, "The `nav.header` setting is no longer supported, use `nav.header_extras` instead"
 		next()
 
 	webRouter.use (req, res, next) ->

--- a/app/views/layout/navbar.jade
+++ b/app/views/layout/navbar.jade
@@ -24,7 +24,10 @@ nav.navbar.navbar-default
 							li
 								a(href="/admin/user") Manage Users
 
-				each item in nav.header
+
+				// loop over header_extras
+				each item in nav.header_extras
+
 					if ((item.only_when_logged_in && getSessionUser()) || (item.only_when_logged_out && (!getSessionUser())) || (!item.only_when_logged_out && !item.only_when_logged_in))
 						if item.dropdown
 							li.dropdown(class=item.class, dropdown)
@@ -35,9 +38,6 @@ nav.navbar.navbar-default
 									each child in item.dropdown
 										if child.divider
 											li.divider
-										else if child.user_email
-											li
-												div.subdued #{getUserEmail()}
 										else
 											li
 												if child.url
@@ -50,7 +50,35 @@ nav.navbar.navbar-default
 									a(href=item.url, class=item.class) !{translate(item.text)}
 								else
 									| !{translate(item.text)}
-				
-				
-				
 
+				// logged out
+				if !getSessionUser()
+					// register link
+					if !externalAuthenticationSystemUsed()
+						li
+							a(href="/register") #{translate('register')}
+
+					// login link
+					li
+						a(href="/login") #{translate('log_in')}
+
+				// projects link and account menu
+				if getSessionUser()
+					li
+						a(href="/projects") #{translate('Projects')}
+					li.dropdown(dropdown)
+						a.dropbodw-toggle(href, dropdown-toggle)
+							| #{translate('Account')}
+							b.caret
+						ul.dropdown-menu
+							li
+								div.subdued #{getUserEmail()}
+							li.divider
+							li
+								a(href="/user/settings") #{translate('Account Settings')}
+							if nav.showSubscriptionLink
+								li
+									a(href="/user/subscription") #{translate('subscription')}
+							li.divider
+							li
+								a(href="/logout") #{translate('log_out')}

--- a/app/views/layout/navbar.jade
+++ b/app/views/layout/navbar.jade
@@ -65,7 +65,7 @@ nav.navbar.navbar-default
 				// projects link and account menu
 				if getSessionUser()
 					li
-						a(href="/projects") #{translate('Projects')}
+						a(href="/project") #{translate('Projects')}
 					li.dropdown(dropdown)
 						a.dropbodw-toggle(href, dropdown-toggle)
 							| #{translate('Account')}

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -335,35 +335,11 @@ module.exports = settings =
 			url: "https://github.com/sharelatex/sharelatex"
 		}]
 
-		header: [{
-			text: "register"
-			url: "/register"
-			only_when_logged_out: true
-		}, {
-			text: "log_in"
-			url: "/login"
-			only_when_logged_out: true
-		}, {
-			text: "Projects"
-			url: "/project"
-			only_when_logged_in: true
-		}, {
-			text: "Account"
-			only_when_logged_in: true
-			dropdown: [{
-				user_email: true
-			},{
-				divider: true
-			}, {
-				text: "Account Settings"
-				url: "/user/settings"
-			}, {
-				divider: true
-			}, {
-				text: "Log out"
-				url: "/logout"
-			}]
-		}]
+		showSubscriptionLink: false
+
+		header_extras: []
+		# Example:
+		#   header_extras: [{text: "Some Page", url: "http://example.com/some/page", class: "subdued"}]
 
 	customisation: {}
 


### PR DESCRIPTION
Move auth parts of top menu out of config and into web templates.

Move the remaining configuration into a new config var: `nav.header_extras`.
Add a `nav.showSubscriptionLink` var to control visibility of subscription link
in the Account menu.

This will allow admins to more easily configure extra links in the top
navigation bar, without the danger of overwriting the important auth menus.