### PR TITLE
Give the scrollbar a background-color, so that Safari knows that it s…

### DIFF
--- a/public/stylesheets/app/editor.less
+++ b/public/stylesheets/app/editor.less
@@ -181,6 +181,19 @@
 	}
 }
 
+// Hack to solve an issue where scrollbars aren't visible in Safari.
+// Safari seems to clip part of the scrollbar element. By giving the 
+// element a background, we're telling Safari that it *really* needs to 
+// paint the whole area. See https://github.com/ajaxorg/ace/issues/2872
+.ace_scrollbar-inner {
+	background-color: #FFF;
+	opacity: 0.01;
+
+	.ace_dark & {
+		background-color: #000;
+	}
+}
+
 .ui-layout-resizer {
 	width: 6px;
 	background-color: #f4f4f4;


### PR DESCRIPTION
…hould paint it.

Fixes invisible scrollbars in Safari, as per https://sharelatex-accounts.groovehq.com/groove_client/mailboxes/33479/filters/183581/tickets/38653216

Issue seems to come from Ace + Safari (Safari probably being the biggest culprit here, when computing non-paintable regions). Solution (and issue) from https://github.com/ajaxorg/ace/issues/2872