### PR TITLE
Avoid blank screen bug, when triggered by very large comments.

### DIFF
--- a/public/stylesheets/app/editor/review-panel.less
+++ b/public/stylesheets/app/editor/review-panel.less
@@ -158,6 +158,8 @@
 		position: absolute;
 		top: 0;
 		bottom: 0;
+		padding-bottom: 52px;
+		overflow: hidden;
 	}
 	
 	.rp-state-overview & {

--- a/public/stylesheets/app/editor/review-panel.less
+++ b/public/stylesheets/app/editor/review-panel.less
@@ -463,6 +463,7 @@
 		margin-top: 3px;
 		overflow-x: hidden;
 		min-height: 3em;
+		max-height: 400px;
 	}
 
 .rp-icon-delete {


### PR DESCRIPTION
Controlling overflowing content (in this case, a textarea which expands with content) seems to fix the issue. 