### PR TITLE
Use solid color instead of opacity, to avoid rendering issues.

### DIFF
--- a/public/stylesheets/app/editor/review-panel.less
+++ b/public/stylesheets/app/editor/review-panel.less
@@ -49,11 +49,11 @@
 	}
 
 	&[disabled] {
-		opacity: 0.5;
+		background-color: tint(@rp-highlight-blue, 50%);
 
 		&:hover,
 		&:focus {
-			background-color: @rp-highlight-blue;
+			background-color: tint(@rp-highlight-blue, 50%);
 		}
 	}
 }


### PR DESCRIPTION
Disabled buttons seemed to have a border-bottom. This was because opacity somehow changed the rendering mode. Solution was to precompute the tinted color, instead of using opacity.