### PR TITLE
z-index syntax & review panel

### DIFF
--- a/public/coffee/ide/directives/layout.coffee
+++ b/public/coffee/ide/directives/layout.coffee
@@ -106,7 +106,14 @@ define [
 							, 0
 
 					if attrs.allowOverflowOn?
-						element.layout().allowOverflow(scope.$eval(attrs.allowOverflowOn))
+						layoutObj = element.layout()
+						overflowPane = scope.$eval(attrs.allowOverflowOn)
+						overflowPaneEl = layoutObj.panes[overflowPane]
+						# Set the panel as overflowing (gives it higher z-index and sets overflow rules)
+						layoutObj.allowOverflow overflowPane
+						# Read the given z-index value and increment it, so that it's higher than synctex controls.
+						overflowPaneZVal = overflowPaneEl.css "z-index"
+						overflowPaneEl.css "z-index", overflowPaneZVal + 1
 
 					resetOpenStates()
 					onInternalResize()

--- a/public/coffee/ide/directives/layout.coffee
+++ b/public/coffee/ide/directives/layout.coffee
@@ -55,7 +55,7 @@ define [
 								controls.css({
 									position: "absolute"
 									right: state.east.size
-									"z-index": 10
+									"z-index": 3
 								})
 
 					resetOpenStates = () ->


### PR DESCRIPTION
* Set the synctex controls to a lower z-index value (was 10, which doesn't seem necessary; 3 seems to be enough);
* Patch the overflowing behaviour in the center (editor) pane. Default overflow would put the pane exactly at the same z-index level than the synctex controls. The latter (as it appears "after" in the DOM) would then be "on top" of the former. Patch ensures that the center pane's z-index is incremented by one.

P.S. Overflowing behaviour, in a jQuery layout context, means that an element is configured to allow child elements to overflow it (e.g. pop-ups, such as the review entries). This is what we want in the center pane.