### PR TITLE
Add option to hard-hide track-changes onboarding.

### DIFF
--- a/app/coffee/Features/Project/ProjectController.coffee
+++ b/app/coffee/Features/Project/ProjectController.coffee
@@ -221,6 +221,8 @@ module.exports = ProjectController =
 				ProjectUpdateHandler.markAsOpened project_id, ->
 				cb()
 			showTrackChangesOnboarding: (cb) ->
+				if Settings.hideTrackChangesOnboarding
+					return cb(null, false)
 				cb = underscore.once(cb)
 				if !user_id?
 					return cb()

--- a/test/UnitTests/coffee/Project/ProjectControllerTests.coffee
+++ b/test/UnitTests/coffee/Project/ProjectControllerTests.coffee
@@ -389,3 +389,11 @@ describe "ProjectController", ->
 				opts.showTrackChangesOnboarding.should.equal false
 				done()
 			@ProjectController.loadEditor @req, @res
+
+		it "should set showTrackChangesOnboarding = false if settings say to hide onboarding", (done) ->
+			@settings.hideTrackChangesOnboarding = true
+			@AnalyticsManager.getLastOccurance.yields(null, null)
+			@res.render = (pageName, opts)=>
+				opts.showTrackChangesOnboarding.should.equal false
+				done()
+			@ProjectController.loadEditor @req, @res


### PR DESCRIPTION
This is useful for on-prem installations where Analytics
services is not operating. Previously the Analytics call
would be a no-op, but that would mean the prompt would be
shown every time a user loaded a project.

It's necessary to have a way to perma-hide this prompt
via settings.