### PR TITLE
If sending email fails, return a generic error.

### DIFF
--- a/app/coffee/Features/Email/EmailSender.coffee
+++ b/app/coffee/Features/Email/EmailSender.coffee
@@ -74,4 +74,4 @@ module.exports =
 					logger.err err:err, "error sending message"
 				else
 					logger.log "Message sent to #{options.to}"
-				callback(err)
+				callback(new Error('Cannot send email'))

--- a/app/coffee/Features/Email/EmailSender.coffee
+++ b/app/coffee/Features/Email/EmailSender.coffee
@@ -72,6 +72,7 @@ module.exports =
 			client.sendMail options, (err, res)->
 				if err?
 					logger.err err:err, "error sending message"
+					err = new Error('Cannot send email')
 				else
 					logger.log "Message sent to #{options.to}"
-				callback(new Error('Cannot send email'))
+				callback(err)

--- a/test/UnitTests/coffee/Email/EmailSenderTests.coffee
+++ b/test/UnitTests/coffee/Email/EmailSenderTests.coffee
@@ -58,10 +58,11 @@ describe "EmailSender", ->
 				args.subject.should.equal @opts.subject
 				done()
 
-		it "should return the error", (done)->
+		it "should return a non-specific error", (done)->
 			@sesClient.sendMail.callsArgWith(1, "error")
 			@sender.sendEmail {}, (err)=>
-				err.should.equal "error"
+				err.should.exist
+				err.toString().should.equal 'Error: Cannot send email'
 				done()
 
 

--- a/test/UnitTests/coffee/Email/EmailSenderTests.coffee
+++ b/test/UnitTests/coffee/Email/EmailSenderTests.coffee
@@ -51,7 +51,8 @@ describe "EmailSender", ->
 		it "should set the properties on the email to send", (done)->
 			@sesClient.sendMail.callsArgWith(1)
 
-			@sender.sendEmail @opts, =>
+			@sender.sendEmail @opts, (err) =>
+				expect(err).to.not.exist
 				args = @sesClient.sendMail.args[0][0]
 				args.html.should.equal @opts.html
 				args.to.should.equal @opts.to


### PR DESCRIPTION
This prevents us from leaking juicy details of our aws/ses setup via the
password-reset form.