### PR TITLE
Set video source only when the onboarding prompt is shown.

### DIFF
--- a/app/views/project/editor/feature-onboarding.pug
+++ b/app/views/project/editor/feature-onboarding.pug
@@ -32,7 +32,7 @@
 					autoplay
 					loop
 				)
-					source(src="/img/onboarding/review-panel/open-review.mp4", type="video/mp4")
+					source(ng-src="{{ '/img/onboarding/review-panel/open-review.mp4' }}", type="video/mp4")
 					img(src="/img/onboarding/review-panel/open-review.gif")
 			div(ng-show="onboarding.innerStep === 2;")
 				video.feat-onboard-video(
@@ -40,7 +40,7 @@
 					autoplay
 					loop
 				)
-					source(src="/img/onboarding/review-panel/commenting.mp4", type="video/mp4")
+					source(ng-src="{{ '/img/onboarding/review-panel/commenting.mp4' }}", type="video/mp4")
 					img(src="/img/onboarding/review-panel/commenting.gif")
 			div(ng-show="onboarding.innerStep === 3;")
 				video.feat-onboard-video(
@@ -48,7 +48,7 @@
 					autoplay
 					loop
 				)
-					source(src="/img/onboarding/review-panel/add-changes.mp4", type="video/mp4")
+					source(ng-src="{{ '/img/onboarding/review-panel/add-changes.mp4' }}", type="video/mp4")
 					img(src="/img/onboarding/review-panel/add-changes.gif")
 			div(ng-show="onboarding.innerStep === 4;")
 				video.feat-onboard-video(
@@ -56,7 +56,7 @@
 					autoplay
 					loop
 				)
-					source(src="/img/onboarding/review-panel/accept-changes.mp4", type="video/mp4")
+					source(ng-src="{{ '/img/onboarding/review-panel/accept-changes.mp4' }}", type="video/mp4")
 					img(src="/img/onboarding/review-panel/accept-changes.gif")
 			button.btn.btn-primary.feat-onboard-nav-btn(
 				ng-click="gotoNextStep();"


### PR DESCRIPTION
During Angular template compilation, HTML is interpreted "as is" by the browser. In Firefox, this means that video elements might prompt downloading and decoding of media assets, even though they end up being removed via falsy `ng-if`s after Angular compilation.

This fix uses `ng-src` instead of plain `src`; this means that the `src` attribute is only set after Angular compilation occurs and only if the element is to be shown.