### PR TITLE
Use ISO strings instead of of date type in locally resolved comments.

### DIFF
--- a/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
+++ b/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
@@ -414,7 +414,7 @@ define [
 			return if !thread?
 			thread.resolved = true
 			thread.resolved_by_user = formatUser(user)
-			thread.resolved_at = new Date()
+			thread.resolved_at = new Date().toISOString()
 			$scope.reviewPanel.resolvedThreadIds[thread_id] = true
 			$scope.$broadcast "comment:resolve_threads", [thread_id]
 		


### PR DESCRIPTION
Resolved threads retrieved from the server use strings to represent the resolution date, while threads resolved in the current session are stored locally using a Date type. This caused Angular ng-repeat to misorder resolved threads; solution was to enforce the same data type (ISO date strings) in the locally resolved threads.