### PR TITLE
Project name tooltip

### DIFF
--- a/app/views/project/editor/header.pug
+++ b/app/views/project/editor/header.pug
@@ -30,6 +30,10 @@ header.toolbar.toolbar-header.toolbar-with-labels(
 		span.name(
 			ng-dblclick="!permissions.admin || startRenaming()",
 			ng-show="!state.renaming"
+			tooltip="{{ project.name }}",
+			tooltip-class="project-name-tooltip"
+			tooltip-placement="bottom",
+			tooltip-append-to-body="true",
 		) {{ project.name }}
 
 		input.form-control(

--- a/app/views/project/editor/header.pug
+++ b/app/views/project/editor/header.pug
@@ -34,6 +34,7 @@ header.toolbar.toolbar-header.toolbar-with-labels(
 			tooltip-class="project-name-tooltip"
 			tooltip-placement="bottom",
 			tooltip-append-to-body="true",
+			tooltip-enable="state.overflowed"
 		) {{ project.name }}
 
 		input.form-control(

--- a/public/coffee/ide/settings/controllers/ProjectNameController.coffee
+++ b/public/coffee/ide/settings/controllers/ProjectNameController.coffee
@@ -2,9 +2,13 @@ define [
 	"base"
 ], (App) ->
 	MAX_PROJECT_NAME_LENGTH = 150
-	App.controller "ProjectNameController", ["$scope", "settings", "ide", ($scope, settings, ide) ->
+	App.controller "ProjectNameController", ["$scope", "$element", "settings", "ide", ($scope, $element, settings, ide) ->
+		projectNameReadOnlyEl = $element.find(".name")[0]
+
 		$scope.state =
 			renaming: false
+			overflowed: false
+
 		$scope.inputs = {}
 
 		$scope.startRenaming = () ->
@@ -29,4 +33,7 @@ define [
 		$scope.$watch "project.name", (name) ->
 			if name?
 				window.document.title = name + " - Online LaTeX Editor ShareLaTeX"
+				$scope.$applyAsync () ->
+					# This ensures that the element is measured *after* the binding is done (i.e. project name is rendered).
+					$scope.state.overflowed = (projectNameReadOnlyEl.scrollWidth > projectNameReadOnlyEl.clientWidth)
 	]

--- a/public/stylesheets/app/invite.less
+++ b/public/stylesheets/app/invite.less
@@ -10,6 +10,12 @@
 	margin-bottom: 30px;
 }
 
+.project-name-tooltip .tooltip-inner {
+	max-width: 80vw;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .project-invite-invalid {
 	.actions {
 		padding-top: 15px;


### PR DESCRIPTION
Currently, project name is truncated at 250px, which doesn't allow users to see the full name. This PR adds a tooltip to the project name in the editor header, showing the full project name. 

Tooltip should only be triggered if the project name is long enough to be truncated.