### PR TITLE
Properly pass project data as JSON and then parse it

### DIFF
--- a/app/views/project/list.pug
+++ b/app/views/project/list.pug
@@ -3,15 +3,11 @@ extends ../layout
 block content
 	//- We need to do .replace(/\//g, '\\/') do that '</script>' -> '<\/script>'
 	//- and doesn't prematurely end the script tag.
-
-
+	script#data(type="application/json").
+		!{JSON.stringify({ projects: projects, tags: tags, notifications: notifications }).replace(/\//g, '\\/')}
 
 	script(type="text/javascript").
-		window.data = {
-			projects: !{JSON.stringify(projects).replace(/\//g, '\\/')},
-			tags: !{JSON.stringify(tags).replace(/\//g, '\\/')},
-			notifications: !{JSON.stringify(notifications).replace(/\//g, '\\/')}
-		};
+		window.data = JSON.parse($("#data").text());
 		window.algolia = {
 			institutions: {
 				app_id:  '#{algolia_app_id}',


### PR DESCRIPTION
We currently JSON encode the data, but then let the browser parse it as javascript. This trips up when there are certain unicode symbols in the project name. If we properly pass it as JSON and then explicitly parse it again client side, then it is ok. We perhaps need to do a more systematic audit of how we pass data to the client, since we have no consistent pattern, and we want to be able to fix things like this everywhere in one go.