### PR TITLE
Fix safari accent handling

### DIFF
--- a/public/js/ace-1.2.5/ace.js
+++ b/public/js/ace-1.2.5/ace.js
@@ -1350,6 +1350,11 @@ if (typeof navigator != "object")
 
 var os = (navigator.platform.match(/mac|win|linux/i) || ["other"])[0].toLowerCase();
 var ua = navigator.userAgent;
+
+var safariRegex = /version\/([\w\.]+).+?(mobile\s?safari|safari)/i;
+var safariResult = ua.match(safariRegex);
+var safariVersion = safariResult ? parseFloat(safariResult[1]) : 0;
+
 exports.isWin = (os == "win");
 exports.isMac = (os == "mac");
 exports.isLinux = (os == "linux");
@@ -1365,6 +1370,8 @@ exports.isOpera = window.opera && Object.prototype.toString.call(window.opera) =
 exports.isWebKit = parseFloat(ua.split("WebKit/")[1]) || undefined;
 
 exports.isChrome = parseFloat(ua.split(" Chrome/")[1]) || undefined;
+
+exports.isSafari = safariVersion || undefined;
 
 exports.isAIR = ua.indexOf("AdobeAIR") >= 0;
 

--- a/public/js/ace-1.2.5/ace.js
+++ b/public/js/ace-1.2.5/ace.js
@@ -2292,7 +2292,7 @@ var TextInput = function(parentNode, host) {
         }
         // WORKAROUND: Accent keys and Korean keys don't work in Chrome >53.
         // https://github.com/ajaxorg/ace/issues/3045
-        if (useragent.isChrome >= 53) onInput();
+        if (useragent.isChrome >= 53 || useragent.isSafari >= 10.1) onInput();
     };
     
     

--- a/public/js/ace-1.2.5/ace.js
+++ b/public/js/ace-1.2.5/ace.js
@@ -1350,11 +1350,6 @@ if (typeof navigator != "object")
 
 var os = (navigator.platform.match(/mac|win|linux/i) || ["other"])[0].toLowerCase();
 var ua = navigator.userAgent;
-
-var safariRegex = /version\/([\w\.]+).+?(mobile\s?safari|safari)/i;
-var safariResult = ua.match(safariRegex);
-var safariVersion = safariResult ? parseFloat(safariResult[1]) : 0;
-
 exports.isWin = (os == "win");
 exports.isMac = (os == "mac");
 exports.isLinux = (os == "linux");
@@ -1370,8 +1365,6 @@ exports.isOpera = window.opera && Object.prototype.toString.call(window.opera) =
 exports.isWebKit = parseFloat(ua.split("WebKit/")[1]) || undefined;
 
 exports.isChrome = parseFloat(ua.split(" Chrome/")[1]) || undefined;
-
-exports.isSafari = safariVersion || undefined;
 
 exports.isAIR = ua.indexOf("AdobeAIR") >= 0;
 
@@ -2290,9 +2283,13 @@ var TextInput = function(parentNode, host) {
         if (e.type == "compositionend" && c.range) {
             host.selection.setRange(c.range);
         }
-        // WORKAROUND: Accent keys and Korean keys don't work in Chrome >53.
-        // https://github.com/ajaxorg/ace/issues/3045
-        if (useragent.isChrome >= 53 || useragent.isSafari >= 10.1) onInput();
+        var needsOnInput =
+            (!!useragent.isChrome && useragent.isChrome >= 53) ||
+            (!!useragent.isWebKit && useragent.isWebKit >= 603);
+
+        if (needsOnInput) {
+          onInput();
+        }
     };
     
     


### PR DESCRIPTION
Ace's custom character composition logic seems to be faulty on new versions of Safari, similarly to what happens in Chrome since version 53. It can be fixed by applying Chrome's workaround to Safari as well. Issue was created in Ace's repo: https://github.com/ajaxorg/ace/issues/3257

Safari detection logic was also added to Ace's useragent lib (it wasn't available before). To keep the API consistent, `isSafari` property works like the existent `isChrome`: if the browser is detected, it returns a float with the version number; otherwise, returns `undefined`.

