### PR TITLE
Error if no project returned from joinProject

### DIFF
--- a/app/views/project/editor.pug
+++ b/app/views/project/editor.pug
@@ -105,10 +105,16 @@ block requirejs
 
 	//- We need to do .replace(/\//g, '\\/') do that '</script>' -> '<\/script>'
 	//- and doesn't prematurely end the script tag.
+	script#data(type="application/json").
+		!{JSON.stringify({userSettings: userSettings, user: user}).replace(/\//g, '\\/')}
+
+	script(type="text/javascript").
+		window.data = JSON.parse($("#data").text());
 	script(type='text/javascript').
 		window.project_id = "!{project_id}";
-		window.userSettings = !{JSON.stringify(userSettings).replace(/\//g, '\\/')};
-		window.user = !{JSON.stringify(user).replace(/\//g, '\\/')};
+		var data = JSON.parse($("#data").text());
+		window.userSettings = data.userSettings;
+		window.user = data.user;
 		window.csrfToken = "!{csrfToken}";
 		window.anonymous = #{anonymous};
 		window.maxDocLength = #{maxDocLength};

--- a/public/coffee/ide/connection/ConnectionManager.coffee
+++ b/public/coffee/ide/connection/ConnectionManager.coffee
@@ -146,7 +146,7 @@ define [], () ->
 			else
 				@ide.socket.disconnect()
 				@ide.showGenericMessageModal("Something went wrong connecting", """
-					Something went wrong connecting to your project. Please refresh is this continues to happen.
+					Something went wrong connecting to your project. Please refresh if this continues to happen.
 				""")
 
 		joinProject: () ->
@@ -157,7 +157,7 @@ define [], () ->
 			@ide.socket.emit 'joinProject', {
 				project_id: @ide.project_id
 			}, (err, project, permissionsLevel, protocolVersion) =>
-				if err?
+				if err? or !project?
 					return @reportConnectionError(err)
 
 				if @$scope.protocolVersion? and @$scope.protocolVersion != protocolVersion


### PR DESCRIPTION
socket.io seems to choke on the unicode project name and just return
undefined when it fails to parse the JSON. I've improved the escaping
of the user data on HTML load, but reporting an error is the best we
can easily do on joinProject via websockets.