### PR TITLE
Prepare bulk actions events

### DIFF
--- a/public/coffee/ide/editor/directives/aceEditor/track-changes/TrackChangesManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/track-changes/TrackChangesManager.coffee
@@ -27,10 +27,16 @@ define [
 				@selectLineIfNoSelection()
 			
 			@$scope.$on "change:accept", (e, change_id) =>
-				@acceptChangeId(change_id)
+				@acceptChangeIds([ change_id ])
 			
 			@$scope.$on "change:reject", (e, change_id) =>
-				@rejectChangeId(change_id)
+				@rejectChangeIds([ change_id ])
+
+			@$scope.$on "change:bulk-accept", (e, change_ids) =>
+				@acceptChangeIds(change_ids)
+
+			@$scope.$on "change:bulk-reject", (e, change_ids) =>
+				@rejectChangeIds(change_ids)
 			
 			@$scope.$on "comment:remove", (e, comment_id) =>
 				@removeCommentId(comment_id)
@@ -207,31 +213,32 @@ define [
 			if @editor.selection.isEmpty()
 				@editor.selection.selectLine()
 		
-		acceptChangeId: (change_id) ->
-			@rangesTracker.removeChangeId(change_id)
+		acceptChangeIds: (change_ids) ->
+			@rangesTracker.removeChangeIds(change_ids)
 			@updateAnnotations()
-		
-		rejectChangeId: (change_id) ->
-			change = @rangesTracker.getChange(change_id)
-			return if !change?
+
+		rejectChangeIds: (change_ids) ->
+			changes = @rangesTracker.getChanges(change_ids)
+			return if changes.length == 0
 			session = @editor.getSession()
-			if change.op.d?
-				content = change.op.d
-				position = @_shareJsOffsetToAcePosition(change.op.p)
-				session.$fromReject = true # Tell track changes to cancel out delete
-				session.insert(position, content)
-				session.$fromReject = false
-			else if change.op.i?
-				start = @_shareJsOffsetToAcePosition(change.op.p)
-				end = @_shareJsOffsetToAcePosition(change.op.p + change.op.i.length)
-				editor_text = session.getDocument().getTextRange({start, end})
-				if editor_text != change.op.i
-					throw new Error("Op to be removed (#{JSON.stringify(change.op)}), does not match editor text, '#{editor_text}'")
-				session.$fromReject = true
-				session.remove({start, end})
-				session.$fromReject = false
-			else
-				throw new Error("unknown change: #{JSON.stringify(change)}")
+			for change in changes
+				if change.op.d?
+					content = change.op.d
+					position = @_shareJsOffsetToAcePosition(change.op.p)
+					session.$fromReject = true # Tell track changes to cancel out delete
+					session.insert(position, content)
+					session.$fromReject = false
+				else if change.op.i?
+					start = @_shareJsOffsetToAcePosition(change.op.p)
+					end = @_shareJsOffsetToAcePosition(change.op.p + change.op.i.length)
+					editor_text = session.getDocument().getTextRange({start, end})
+					if editor_text != change.op.i
+						throw new Error("Op to be removed (#{JSON.stringify(change.op)}), does not match editor text, '#{editor_text}'")
+					session.$fromReject = true
+					session.remove({start, end})
+					session.$fromReject = false
+				else
+					throw new Error("unknown change: #{JSON.stringify(change)}")
 
 		removeCommentId: (comment_id) ->
 			@rangesTracker.removeCommentId(comment_id)

--- a/public/coffee/ide/review-panel/RangesTracker.coffee
+++ b/public/coffee/ide/review-panel/RangesTracker.coffee
@@ -96,6 +96,20 @@ load = () ->
 					break
 			return change
 
+		getChanges: (change_ids) ->
+			changes_response = []
+			ids_map = {}
+
+			for change_id in change_ids
+				ids_map[change_id] = true
+
+			for change in @changes
+				if ids_map[change.id]
+					delete ids_map[change.id]
+					changes_response.push change
+
+			return changes_response
+
 		removeChangeId: (change_id) ->
 			change = @getChange(change_id)
 			return if !change?

--- a/public/coffee/ide/review-panel/RangesTracker.coffee
+++ b/public/coffee/ide/review-panel/RangesTracker.coffee
@@ -108,13 +108,16 @@ load = () ->
 			for change_id in change_to_remove_ids
 				remove_change_id[change_id] = true
 
-			while (i--)
-				if remove_change_id[@changes[i].id]
-					delete remove_change_id[@changes[i].id]
-					removed_change = @changes.splice(i, 1)[0]
-					@_markAsDirty removed_change, "change", "removed"
-					if Object.keys(remove_change_id).length == 0
-						break
+			remaining_changes = []
+
+			for change in @changes
+				if remove_change_id[change.id]
+					delete remove_change_id[change.id]
+					@_markAsDirty change, "change", "removed"
+				else
+					remaining_changes.push change
+
+			@changes = remaining_changes
 		
 		validate: (text) ->
 			for change in @changes

--- a/public/coffee/ide/review-panel/RangesTracker.coffee
+++ b/public/coffee/ide/review-panel/RangesTracker.coffee
@@ -100,6 +100,21 @@ load = () ->
 			change = @getChange(change_id)
 			return if !change?
 			@_removeChange(change)
+
+		removeChangeIds: (change_to_remove_ids) ->
+			return if !change_to_remove_ids?.length > 0
+			i = @changes.length
+			remove_change_id = {} 
+			for change_id in change_to_remove_ids
+				remove_change_id[change_id] = true
+
+			while (i--)
+				if remove_change_id[@changes[i].id]
+					delete remove_change_id[@changes[i].id]
+					removed_change = @changes.splice(i, 1)[0]
+					@_markAsDirty removed_change, "change", "removed"
+					if Object.keys(remove_change_id).length == 0
+						break
 		
 		validate: (text) ->
 			for change in @changes

--- a/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
+++ b/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
@@ -76,6 +76,14 @@ define [
 				$scope.$broadcast "change:accept", change_id
 			updateEntries(doc_id)
 			$scope.$apply () ->
+
+		ide.socket.on "accept-changes", (doc_id, change_ids) ->
+			if doc_id != $scope.editor.open_doc_id
+				getChangeTracker(doc_id).removeChangeIds(change_ids)
+			else
+				$scope.$broadcast "change:bulk-accept", change_ids
+			updateEntries(doc_id)
+			$scope.$apply () ->
 		
 		ide.socket.on "resolve-thread", (thread_id, user) ->
 			_onCommentResolved(thread_id, user)


### PR DESCRIPTION
Mostly code to prepare https://github.com/sharelatex/web-sharelatex/pull/498 

Some clients might have outdated code bundles in the front-end (cache), making them unable to process the new socket events added in the PR above. This PR—to be merged beforehand—will ensure that clients will at least be able to handle the new events (i.e. receive remote bulk actions). 