### PR TITLE
Check for blank string in clsi cookie caching

### DIFF
--- a/app/coffee/Features/Compile/ClsiCookieManager.coffee
+++ b/app/coffee/Features/Compile/ClsiCookieManager.coffee
@@ -19,10 +19,10 @@ module.exports = ClsiCookieManager =
 		rclient.get buildKey(project_id), (err, serverId)->
 			if err?
 				return callback(err)
-			if serverId?
-				return callback(null, serverId)
-			else
+			if !serverId? or serverId == ""
 				return ClsiCookieManager._populateServerIdViaRequest project_id, callback
+			else
+				return callback(null, serverId)
 
 
 	_populateServerIdViaRequest :(project_id, callback = (err, serverId)->)->

--- a/test/UnitTests/coffee/Compile/ClsiCookieManagerTests.coffee
+++ b/test/UnitTests/coffee/Compile/ClsiCookieManagerTests.coffee
@@ -60,6 +60,13 @@ describe "ClsiCookieManager", ->
 				@ClsiCookieManager._populateServerIdViaRequest.calledWith(@project_id).should.equal true
 				done()
 
+		it "should _populateServerIdViaRequest if no key is blank", (done)->
+			@ClsiCookieManager._populateServerIdViaRequest = sinon.stub().callsArgWith(1)
+			@redis.get.callsArgWith(1, null, "")
+			@ClsiCookieManager._getServerId @project_id, (err, serverId)=>
+				@ClsiCookieManager._populateServerIdViaRequest.calledWith(@project_id).should.equal true
+				done()
+
 
 	describe "_populateServerIdViaRequest", ->
 


### PR DESCRIPTION
ioredis returns "" for a blank entry, the previous driver returned null,
so also check for a blank string