### PR TITLE
Hide review panel+keyboard shortcuts for review

### DIFF
--- a/app/views/project/editor/editor.pug
+++ b/app/views/project/editor/editor.pug
@@ -51,6 +51,8 @@ div.full-size(
 			file-name="editor.open_doc_name",
 			on-ctrl-enter="recompileViaKey",
 			on-ctrl-j="toggleReviewPanel",
+			on-ctrl-shift-c="addNewCommentFromKbdShortcut",
+			on-ctrl-shift-a="toggleTrackChangesFromKbdShortcut",
 			syntax-validation="settings.syntaxValidation",
 			review-panel="reviewPanel",
 			events-bridge="reviewPanelEventsBridge"

--- a/app/views/project/editor/editor.pug
+++ b/app/views/project/editor/editor.pug
@@ -50,6 +50,7 @@ div.full-size(
 			read-only="!permissions.write",
 			file-name="editor.open_doc_name",
 			on-ctrl-enter="recompileViaKey",
+			on-ctrl-j="toggleReviewPanel",
 			syntax-validation="settings.syntaxValidation",
 			review-panel="reviewPanel",
 			events-bridge="reviewPanelEventsBridge"

--- a/app/views/project/editor/hotkeys.pug
+++ b/app/views/project/editor/hotkeys.pug
@@ -9,38 +9,38 @@ script(type="text/ng-template", id="hotkeysModalTemplate")
 	.modal-body.modal-hotkeys
 		h3 #{translate("common")}
 		.row
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + F
 					span.description Find (and replace)
 				.hotkey
 					span.combination {{ctrl}} + Enter
 					span.description Compile
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + Z
 					span.description Undo
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + Y
 					span.description Redo
-
 		h3 #{translate("navigation")}
 		.row
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + Home
 					span.description  Beginning of document
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + End
 					span.description End of document
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + L
 					span.description Go To Line
-
 		h3 #{translate("editing")}
 		.row
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + /
 					span.description Toggle Comment
@@ -50,16 +50,17 @@ script(type="text/ng-template", id="hotkeysModalTemplate")
 				.hotkey
 					span.combination {{ctrl}} + A
 					span.description Select All
-				.hotkey
-					span.combination Tab
-					span.description Indent Selection
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination Ctrl + U
 					span.description To Uppercase
 				.hotkey
 					span.combination Ctrl + Shift + U
 					span.description To Lowercase
+				.hotkey
+					span.combination Tab
+					span.description Indent Selection
+			.col-xs-4
 				.hotkey
 					span.combination {{ctrl}} + B
 					span.description Bold text
@@ -69,27 +70,40 @@ script(type="text/ng-template", id="hotkeysModalTemplate")
 	
 		h3 #{translate("autocomplete")}
 		.row
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination Ctrl + Space
 					span.description Autocomplete Menu
-
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination Tab / Up / Down
 					span.description Select Candidate
-
+			.col-xs-4
 				.hotkey
 					span.combination Enter
 					span.description Insert Candidate
 	
 		h3 !{translate("autocomplete_references")}
 		.row
-			.col-xs-6
+			.col-xs-4
 				.hotkey
 					span.combination Ctrl + Space 
 					span.description Search References
 		
+		h3 #{translate("review")}
+		.row
+			.col-xs-4
+				.hotkey
+					span.combination {{ctrl}} + J
+					span.description Toggle review panel
+			.col-xs-4
+				.hotkey
+					span.combination {{ctrl}} + Shift + A
+					span.description Toggle track changes
+			.col-xs-4
+				.hotkey
+					span.combination {{ctrl}} + Shift + C
+					span.description Add a comment
 					
 	.modal-footer
 		button.btn.btn-default(

--- a/app/views/project/editor/review-panel.pug
+++ b/app/views/project/editor/review-panel.pug
@@ -13,6 +13,10 @@
 		) 
 			i.fa.fa-comment
 			| &nbsp;#{translate("add_comment")}
+	a.review-panel-toggler(
+		href
+		ng-click="toggleReviewPanel();"
+	)
 	.review-panel-toolbar
 		resolved-comments-dropdown(
 			class="rp-flex-block"

--- a/app/views/project/editor/review-panel.pug
+++ b/app/views/project/editor/review-panel.pug
@@ -31,7 +31,7 @@
 			| &nbsp;#{translate("add_comment")}
 	a.review-panel-toggler(
 		href
-		ng-click="toggleReviewPanel();"
+		ng-click="handleTogglerClick($event);"
 	)
 	.review-panel-toolbar
 		resolved-comments-dropdown(

--- a/public/coffee/ide/editor/directives/aceEditor.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor.coffee
@@ -180,9 +180,7 @@ define [
 							name: "add-new-comment",
 							bindKey: win: "Ctrl-Shift-C", mac: "Command-Shift-C"
 							exec: (editor) =>
-								selection = editor.getSelection()
-								if !selection.isEmpty()
-									callback()
+								callback()
 							readOnly: true
 
 				scope.$watch "onCtrlShiftA", (callback) ->

--- a/public/coffee/ide/editor/directives/aceEditor.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor.coffee
@@ -51,6 +51,7 @@ define [
 				navigateHighlights: "="
 				fileName: "="
 				onCtrlEnter: "="
+				onCtrlJ: "="
 				syntaxValidation: "="
 				reviewPanel: "="
 				eventsBridge: "="
@@ -158,6 +159,15 @@ define [
 						editor.commands.addCommand 
 							name: "compile",
 							bindKey: win: "Ctrl-Enter", mac: "Command-Enter"
+							exec: (editor) =>
+								callback()
+							readOnly: true
+
+				scope.$watch "onCtrlJ", (callback) ->
+					if callback?
+						editor.commands.addCommand 
+							name: "toggle-review-panel",
+							bindKey: win: "Ctrl-J", mac: "Command-J"
 							exec: (editor) =>
 								callback()
 							readOnly: true

--- a/public/coffee/ide/editor/directives/aceEditor.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor.coffee
@@ -50,8 +50,10 @@ define [
 				annotations: "="
 				navigateHighlights: "="
 				fileName: "="
-				onCtrlEnter: "="
-				onCtrlJ: "="
+				onCtrlEnter: "="   # Compile
+				onCtrlJ: "="       # Toggle the review panel
+				onCtrlShiftC: "="  # Add a new comment
+				onCtrlShiftA: "="  # Toggle track-changes on/off
 				syntaxValidation: "="
 				reviewPanel: "="
 				eventsBridge: "="
@@ -168,6 +170,26 @@ define [
 						editor.commands.addCommand 
 							name: "toggle-review-panel",
 							bindKey: win: "Ctrl-J", mac: "Command-J"
+							exec: (editor) =>
+								callback()
+							readOnly: true
+
+				scope.$watch "onCtrlShiftC", (callback) ->
+					if callback?
+						editor.commands.addCommand 
+							name: "add-new-comment",
+							bindKey: win: "Ctrl-Shift-C", mac: "Command-Shift-C"
+							exec: (editor) =>
+								selection = editor.getSelection()
+								if !selection.isEmpty()
+									callback()
+							readOnly: true
+
+				scope.$watch "onCtrlShiftA", (callback) ->
+					if callback?
+						editor.commands.addCommand 
+							name: "toggle-track-changes",
+							bindKey: win: "Ctrl-Shift-A", mac: "Command-Shift-A"
 							exec: (editor) =>
 								callback()
 							readOnly: true

--- a/public/coffee/ide/hotkeys/controllers/HotkeysController.coffee
+++ b/public/coffee/ide/hotkeys/controllers/HotkeysController.coffee
@@ -9,6 +9,7 @@ define [
 			$modal.open {
 				templateUrl: "hotkeysModalTemplate"
 				controller:  "HotkeysModalController"
+				size: "lg"
 			}
 		
 	App.controller "HotkeysModalController", ($scope, $modalInstance)->

--- a/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
+++ b/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
@@ -375,6 +375,10 @@ define [
 				else
 					bulkReject()
 
+		$scope.handleTogglerClick = (e) ->
+			e.target.blur()
+			$scope.toggleReviewPanel()
+
 		$scope.addNewComment = () ->
 			$scope.$broadcast "comment:start_adding"
 			$scope.toggleReviewPanel()

--- a/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
+++ b/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
@@ -329,6 +329,11 @@ define [
 			$scope.$broadcast "comment:start_adding"
 			$scope.toggleReviewPanel()
 
+		$scope.addNewCommentFromKbdShortcut = () ->
+			$scope.$broadcast "comment:start_adding"
+			if !$scope.ui.reviewPanelOpen
+				$scope.toggleReviewPanel()
+
 		$scope.startNewComment = () ->
 			$scope.$broadcast "comment:select_line"
 			$timeout () ->
@@ -479,6 +484,12 @@ define [
 				event_tracking.sendMB "rp-trackchanges-toggle", { value }
 			else
 				$scope.openTrackChangesUpgradeModal()
+
+		$scope.toggleTrackChangesFromKbdShortcut = () ->
+			if $scope.editor.wantTrackChanges
+				$scope.toggleTrackChanges false
+			else 
+				$scope.toggleTrackChanges true
 		
 		ide.socket.on "toggle-track-changes", (value) ->
 			$scope.$apply () ->

--- a/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
+++ b/public/coffee/ide/review-panel/controllers/ReviewPanelController.coffee
@@ -380,9 +380,12 @@ define [
 			$scope.toggleReviewPanel()
 
 		$scope.addNewCommentFromKbdShortcut = () ->
-			$scope.$broadcast "comment:start_adding"
+			$scope.$broadcast "comment:select_line"
 			if !$scope.ui.reviewPanelOpen
 				$scope.toggleReviewPanel()
+			$timeout () ->
+				$scope.$broadcast "review-panel:layout"	
+				$scope.$broadcast "comment:start_adding"
 
 		$scope.startNewComment = () ->
 			$scope.$broadcast "comment:select_line"

--- a/public/stylesheets/app/editor/review-panel.less
+++ b/public/stylesheets/app/editor/review-panel.less
@@ -937,6 +937,41 @@
 		}
 	}
 
+.review-panel-toggler {
+	display: none;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 10px;
+	opacity: 0.5;
+	color: @rp-highlight-blue;
+	z-index: 1;
+	cursor: e-resize;
+
+	.rp-size-expanded & {
+		display: block;
+	}
+
+	&:hover {
+		opacity: 1;
+		color: @rp-highlight-blue;
+	}
+
+	&::after {
+		content: "\f105";
+		font-family: FontAwesome;
+		line-height: 1;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		font-size: 16px;
+		display: block;
+		position: absolute;
+		top: 50%;
+		width: 100%;
+		text-align: center;
+		margin-top: -0.5em;
+	}
+}
 // Helper class for elements which aren't treated as flex-items by IE10, e.g:
 // * inline items;
 // * unknown elements (elements which aren't standard DOM elements, such as custom element directives)

--- a/public/stylesheets/app/editor/review-panel.less
+++ b/public/stylesheets/app/editor/review-panel.less
@@ -972,7 +972,8 @@
 	opacity: 0.5;
 	color: @rp-highlight-blue;
 	z-index: 1;
-	cursor: e-resize;
+	background-color: transparent;
+	transition: background 0.1s;
 
 	.rp-size-expanded & {
 		display: block;
@@ -980,8 +981,8 @@
 
 	&:hover,
 	&:focus {
-		opacity: 1;
 		color: @rp-highlight-blue;
+		background-color: #FFF;
 	}
 
 	&::after {

--- a/public/stylesheets/app/editor/review-panel.less
+++ b/public/stylesheets/app/editor/review-panel.less
@@ -952,7 +952,8 @@
 		display: block;
 	}
 
-	&:hover {
+	&:hover,
+	&:focus {
 		opacity: 1;
 		color: @rp-highlight-blue;
 	}

--- a/public/stylesheets/app/editor/review-panel.less
+++ b/public/stylesheets/app/editor/review-panel.less
@@ -964,7 +964,7 @@
 	}
 
 .review-panel-toggler {
-	display: none;
+	// display: none;
 	position: absolute;
 	top: 0;
 	bottom: 0;
@@ -976,7 +976,9 @@
 	transition: background 0.1s;
 
 	.rp-size-expanded & {
-		display: block;
+		&::after {
+			content: "\f105";
+		}
 	}
 
 	&:hover,
@@ -986,7 +988,7 @@
 	}
 
 	&::after {
-		content: "\f105";
+		content: "\f104";
 		font-family: FontAwesome;
 		line-height: 1;
 		-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This PR adds:

* The ability to hide the review panel when clicking on the left border + a little arrow (like in the other panel splitters)
* Keyboard shortcuts for review features
    * Cmd/Ctrl + J to toggle the review panel
    * Cmd/Ctrl + Shift + A to toggle track-changes on or off
    * Cmd/Ctrl + Shift + T to add comments
    * (Adds the keyboard shortcuts to the hotkeys modals and re-arranges it—it was getting too small)