### PR TITLE
Make the alert container a zero-height static element, to avoid capt…

### DIFF
--- a/public/stylesheets/app/editor.less
+++ b/public/stylesheets/app/editor.less
@@ -35,11 +35,8 @@
 }
 
 .global-alerts {
-	position: absolute;
-	z-index: 20;
-	top: 2px;
-	left: 0;
-	right: 0;
+	height: 0;
+	margin-top: 2px;
 	text-align: center;
 
 	.alert {
@@ -49,6 +46,8 @@
 		padding: (@line-height-computed / 4);
 		font-size: 14px;
 		margin-bottom: (@line-height-computed / 4);
+		position: relative;
+		z-index: 20;
 	}
 }
 	#try-reconnect-now-button {


### PR DESCRIPTION
…uring clicks.

`pointer-events: none` would be the simplest solution, but it lacks IE10 support.