### PR TITLE
Revert "use a single pdfjs worker, rotated to avoid leaks"

### DIFF
--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -6,22 +6,6 @@ define [
 
 	App.factory 'PDFRenderer', ['$q', '$timeout', 'pdfAnnotations', 'pdfTextLayer', 'pdfSpinner', ($q, $timeout, pdfAnnotations, pdfTextLayer, pdfSpinner) ->
 
-		# Have a single worker used by all rendering, to avoid reloading
-		RenderThread = { worker: null, count: 0}
-
-		getRenderThread = () ->
-			if RenderThread.count > 16 # recycle the worker periodically to avoid leaks
-				RenderThread.readyToDestroy = true
-				RenderThread = { worker: null, count: 0 }
-			RenderThread.worker ||= new PDFJS.PDFWorker('pdfjsworker')
-			RenderThread.count++
-			return RenderThread
-
-		resetWorker = (thread) ->
-			thread.worker.destroy() if thread.readyToDestroy
-
-		# The PDF page renderer
-
 		class PDFRenderer
 			JOB_QUEUE_INTERVAL: 25
 			PAGE_LOAD_TIMEOUT: 60*1000
@@ -43,8 +27,7 @@ define [
 				# PDFJS.disableStream
 				# PDFJS.disableRange
 				@scale = @options.scale || 1
-				@thread = getRenderThread()
-				@pdfjs = PDFJS.getDocument {url: @url, rangeChunkSize: 2*65536, worker: @thread.worker}
+				@pdfjs = PDFJS.getDocument {url: @url, rangeChunkSize: 2*65536}
 				@pdfjs.onProgress = @options.progressCallback
 				@document = $q.when(@pdfjs)
 				@navigateFn = @options.navigateFn
@@ -353,9 +336,8 @@ define [
 			destroy: () ->
 				@shuttingDown = true
 				@resetState()
-				@pdfjs.then (document) =>
+				@pdfjs.then (document) ->
 					document.cleanup()
 					document.destroy()
-					resetWorker(@thread)
 
 		]


### PR DESCRIPTION
This reverts commit f270ef54911acd800d2ffd577080b50ea2fe4aff.

Use a new worker on each reload to free up memory.

Keeping the worker was using more memory and not making the rendering any faster.