### PR TITLE
set text layer to display:none for faster scroll

### DIFF
--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -405,6 +405,16 @@ define [
 						scope.adjustingScroll = true
 						element.scrollTop(currentScrollTop + delta)
 
+				element.on 'mouseover', '.pdf-page-container', (e) ->
+					pdfPageEl = $(e.currentTarget)
+
+					pdfPageEl.find('.plv-text-layer').addClass('plv-text-layer-visible')
+					pdfPageEl.prev().find('.plv-text-layer').addClass('plv-text-layer-visible')
+					pdfPageEl.next().find('.plv-text-layer').addClass('plv-text-layer-visible')
+
+				element.on 'mouseout', '.pdf-page-container', (e) ->
+					$('.plv-text-layer-visible').removeClass('plv-text-layer-visible')
+
 				element.on 'scroll', () ->
 					#console.log 'scroll event', element.scrollTop(), 'adjusting?', scope.adjustingScroll
 					#scope.scrollPosition = element.scrollTop()

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -405,15 +405,37 @@ define [
 						scope.adjustingScroll = true
 						element.scrollTop(currentScrollTop + delta)
 
-				element.on 'mouseover', '.pdf-page-container', (e) ->
-					pdfPageEl = $(e.currentTarget)
+				element.on 'mousedown', (e) ->
+					if !_hasSelection()
+						console.log 'adding class'
+						element.addClass 'pdfjs-viewer-show-text'
+						$(document.body).one 'mouseup', _handleSelectionMouseUp
 
-					pdfPageEl.find('.plv-text-layer').addClass('plv-text-layer-visible')
-					pdfPageEl.prev().find('.plv-text-layer').addClass('plv-text-layer-visible')
-					pdfPageEl.next().find('.plv-text-layer').addClass('plv-text-layer-visible')
+				_handleSelectionMouseUp = () ->
+					window.setTimeout _removeClassIfNoSelection, 10
 
-				element.on 'mouseout', '.pdf-page-container', (e) ->
-					$('.plv-text-layer-visible').removeClass('plv-text-layer-visible')
+				_removeClassIfNoSelection = () ->
+					if _hasSelection()
+						console.log 'has selection, keeping class'
+						$(document.body).one 'mouseup', _handleSelectionMouseUp
+					else
+						console.log 'no selection, removing class'
+						element.removeClass 'pdfjs-viewer-show-text'
+
+				_hasSelection = () ->
+					selection = window.getSelection()
+					if _isSelectionWithinPDF(selection) and selection.toString() != ''
+						console.log 'selection within and not empty' + selection.toString()
+						return true
+					else 
+						console.log 'selection outside or empty'
+						return false
+
+				_isSelectionWithinPDF = (selection) ->
+					if selection.rangeCount == 0
+						return false
+					selectionAncestorNode = selection.getRangeAt(0).commonAncestorContainer
+					return element.find(selectionAncestorNode).length > 0 or element.is(selectionAncestorNode)
 
 				element.on 'scroll', () ->
 					#console.log 'scroll event', element.scrollTop(), 'adjusting?', scope.adjustingScroll

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -441,11 +441,11 @@ define [
 						return true
 
 				_hasSelection = () ->
-					selection = window.getSelection()
+					selection = window.getSelection?()
 					# check the selection type in preference to using
 					# selection.toString() as the latter is "" when the
 					# selection is hidden (e.g. while viewing logs)
-					return _isSelectionWithinPDF(selection) and selection.type is 'Range'
+					return selection? and _isSelectionWithinPDF(selection) and selection.type is 'Range'
 
 				_isSelectionWithinPDF = (selection) ->
 					if selection.rangeCount == 0

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -432,6 +432,7 @@ define [
 						# if we still have a selection we need to keep the handler going
 						if not removedClass then _setMouseUpHandler()
 					, 10
+					return true
 
 				_removeClassIfNoSelection = () ->
 					if _hasSelection()

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -442,10 +442,10 @@ define [
 
 				_hasSelection = () ->
 					selection = window.getSelection?()
-					# check the selection type in preference to using
-					# selection.toString() as the latter is "" when the
-					# selection is hidden (e.g. while viewing logs)
-					return selection? and _isSelectionWithinPDF(selection) and selection.type is 'Range'
+					# check the selection collapsed state in preference to
+					# using selection.toString() as the latter is "" when 
+					# the selection is hidden (e.g. while viewing logs)
+					return selection? and _isSelectionWithinPDF(selection) and !selection.isCollapsed
 
 				_isSelectionWithinPDF = (selection) ->
 					if selection.rangeCount == 0

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -442,7 +442,10 @@ define [
 
 				_hasSelection = () ->
 					selection = window.getSelection()
-					return _isSelectionWithinPDF(selection) and selection.toString() != ''
+					# check the selection type in preference to using
+					# selection.toString() as the latter is "" when the
+					# selection is hidden (e.g. while viewing logs)
+					return _isSelectionWithinPDF(selection) and selection.type is 'Range'
 
 				_isSelectionWithinPDF = (selection) ->
 					if selection.rangeCount == 0

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -417,16 +417,28 @@ define [
 					# grey background area or the scrollbars.
 					if e.target != element[0] and !_hasSelection()
 						element.addClass 'pdfjs-viewer-show-text'
-						$(document.body).one 'mouseup', _handleSelectionMouseUp
+						_setMouseUpHandler()
+
+				mouseUpHandler = null # keep track of the handler to avoid adding multiple times
+
+				_setMouseUpHandler = () ->
+					if not mouseUpHandler?
+						mouseUpHandler = $(document.body).one 'mouseup', _handleSelectionMouseUp
 
 				_handleSelectionMouseUp = () ->
-					window.setTimeout _removeClassIfNoSelection, 10
+					mouseUpHandler = null # reset handler, has now fired
+					window.setTimeout () ->
+						removedClass = _removeClassIfNoSelection()
+						# if we still have a selection we need to keep the handler going
+						if not removedClass then _setMouseUpHandler()
+					, 10
 
 				_removeClassIfNoSelection = () ->
 					if _hasSelection()
-						$(document.body).one 'mouseup', _handleSelectionMouseUp
+						return false # didn't remove the text layer
 					else
 						element.removeClass 'pdfjs-viewer-show-text'
+						return true
 
 				_hasSelection = () ->
 					selection = window.getSelection()

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -323,6 +323,8 @@ define [
 									clearTimeout spinnerTimer
 								else
 									spinner.remove(element)
+								# stop displaying the text layer
+								element.removeClass 'pdfjs-viewer-show-text'
 								ctrl.redraw(origposition)
 								$timeout renderVisiblePages
 								scope.loadSuccess = true

--- a/public/coffee/ide/pdfng/directives/pdfViewer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfViewer.coffee
@@ -406,8 +406,14 @@ define [
 						element.scrollTop(currentScrollTop + delta)
 
 				element.on 'mousedown', (e) ->
-					if !_hasSelection()
-						console.log 'adding class'
+					# We're checking that the event target isn't the directive root element 
+					# to make sure that the click was within a PDF page - no point in showing
+					# the text layer when the click is outside.
+					# If the user clicks a PDF page, the mousedown target will be the canvas
+					# element (or the text layer one). Alternatively, if the event target is
+					# the root element, we can assume that the user has clicked either the 
+					# grey background area or the scrollbars.
+					if e.target != element[0] and !_hasSelection()
 						element.addClass 'pdfjs-viewer-show-text'
 						$(document.body).one 'mouseup', _handleSelectionMouseUp
 
@@ -416,20 +422,13 @@ define [
 
 				_removeClassIfNoSelection = () ->
 					if _hasSelection()
-						console.log 'has selection, keeping class'
 						$(document.body).one 'mouseup', _handleSelectionMouseUp
 					else
-						console.log 'no selection, removing class'
 						element.removeClass 'pdfjs-viewer-show-text'
 
 				_hasSelection = () ->
 					selection = window.getSelection()
-					if _isSelectionWithinPDF(selection) and selection.toString() != ''
-						console.log 'selection within and not empty' + selection.toString()
-						return true
-					else 
-						console.log 'selection outside or empty'
-						return false
+					return _isSelectionWithinPDF(selection) and selection.toString() != ''
 
 				_isSelectionWithinPDF = (selection) ->
 					if selection.rangeCount == 0

--- a/public/stylesheets/app/editor/pdf.less
+++ b/public/stylesheets/app/editor/pdf.less
@@ -352,3 +352,13 @@
 	.files-dropdown {
 		display: inline-block;
 	}
+
+.plv-text-layer {
+	display: none;
+	& > div {
+		color: red;
+	}
+	&.plv-text-layer-visible {
+		display: block;
+	}
+}

--- a/public/stylesheets/app/editor/pdf.less
+++ b/public/stylesheets/app/editor/pdf.less
@@ -37,6 +37,20 @@
 			margin: 10px auto;
 			padding: 0 10px;
 			box-sizing: content-box;
+			// don't display the text layer by default,
+			// it slows down scrolling
+			div.plv-text-layer {
+				display: none;
+			}
+			// display it if we are hovering over the page
+			// so it's selectable
+			// FIXME: need to work out a solution to
+			// select text across multiple pages
+			&:hover {
+				div.plv-text-layer {
+					display: block;
+				}
+			}
 		}
 	}
 	.progress-thin {

--- a/public/stylesheets/app/editor/pdf.less
+++ b/public/stylesheets/app/editor/pdf.less
@@ -37,20 +37,6 @@
 			margin: 10px auto;
 			padding: 0 10px;
 			box-sizing: content-box;
-			// don't display the text layer by default,
-			// it slows down scrolling
-			div.plv-text-layer {
-				display: none;
-			}
-			// display it if we are hovering over the page
-			// so it's selectable
-			// FIXME: need to work out a solution to
-			// select text across multiple pages
-			&:hover {
-				div.plv-text-layer {
-					display: block;
-				}
-			}
 		}
 	}
 	.progress-thin {

--- a/public/stylesheets/app/editor/pdf.less
+++ b/public/stylesheets/app/editor/pdf.less
@@ -23,6 +23,7 @@
 		.full-size;
 		background-color: @gray-lighter;
 		overflow: scroll;
+		user-select: none;
 		canvas, div.pdf-canvas {
 			background: white;
 			box-shadow: black 0px 0px 10px;
@@ -341,10 +342,14 @@
 
 .plv-text-layer {
 	display: none;
+	user-select: text;
+	
+	.pdf-page-container:hover &,
+	.pdfjs-viewer-show-text & {
+		display: block;
+	}
+
 	& > div {
 		color: red;
-	}
-	&.plv-text-layer-visible {
-		display: block;
 	}
 }

--- a/public/stylesheets/app/editor/pdf.less
+++ b/public/stylesheets/app/editor/pdf.less
@@ -23,7 +23,6 @@
 		.full-size;
 		background-color: @gray-lighter;
 		overflow: scroll;
-		user-select: none;
 		canvas, div.pdf-canvas {
 			background: white;
 			box-shadow: black 0px 0px 10px;
@@ -38,6 +37,7 @@
 			margin: 10px auto;
 			padding: 0 10px;
 			box-sizing: content-box;
+			user-select: none;
 		}
 	}
 	.progress-thin {

--- a/public/stylesheets/app/editor/pdf.less
+++ b/public/stylesheets/app/editor/pdf.less
@@ -348,8 +348,4 @@
 	.pdfjs-viewer-show-text & {
 		display: block;
 	}
-
-	& > div {
-		color: red;
-	}
 }

--- a/public/stylesheets/app/editor/toolbar.less
+++ b/public/stylesheets/app/editor/toolbar.less
@@ -10,6 +10,7 @@
 			right: 0;
 			padding: .15em .6em .2em;
 			font-size: 60%;
+			pointer-events: none; // Labels were capturing button/anchor clicks.
 		}
 	}
 


### PR DESCRIPTION
this needs some work, as we would like to select text across multiple pages -- as is currently possible,
but the scrolling is MUCH faster