### PR TITLE
Instantiate the ses client if explicitly specified.

### DIFF
--- a/app/coffee/Features/Email/EmailSender.coffee
+++ b/app/coffee/Features/Email/EmailSender.coffee
@@ -18,7 +18,7 @@ client =
 		logger.log options:options, "Would send email if enabled."
 		callback()
 
-if Settings?.email?.parameters?.AWSAccessKeyID?
+if Settings?.email?.parameters?.AWSAccessKeyID? or Settings?.email?.driver == 'ses'
 	logger.log "using aws ses for email"
 	nm_client = nodemailer.createTransport(sesTransport(Settings.email.parameters))
 else if Settings?.email?.parameters?.sendgridApiKey?


### PR DESCRIPTION
This allows end-users to use AWS features such as instance roles,
avoiding the use of explicit crendentials