### PR TITLE
Add an error handler to Raven loader.

### DIFF
--- a/app/views/sentry.pug
+++ b/app/views/sentry.pug
@@ -72,6 +72,8 @@
 				// whitelistUrls: ['example.com/scripts/']
 				}).install();
 			}
+		}, function(err) {
+			console.log(">> error loading raven", err);
 		})
 	- if (user && typeof(user) != "undefined" && typeof (user.email) != "undefined")
 		script(type="text/javascript").


### PR DESCRIPTION
This should allow app to continue to work if loading Raven
times out.