### PR TITLE
Fix typo in ng-repeat directive.

### DIFF
--- a/app/views/project/list/side-bar.pug
+++ b/app/views/project/list/side-bar.pug
@@ -48,7 +48,7 @@
 		li
 			h2 #{translate("folders")}
 		li.tag(
-			ng-repeat="tag in tags | orderBy:name",
+			ng-repeat="tag in tags | orderBy:'name'",
 			ng-class="{active: tag.selected}",
 			ng-cloak,
 			ng-click="selectTag(tag)"


### PR DESCRIPTION
Sorts the ordering of tags—we were using 'name' as a variable, not as a property.