### PR TITLE
Correct count of uncategorized projects

### DIFF
--- a/public/coffee/main/project-list/project-list.coffee
+++ b/public/coffee/main/project-list/project-list.coffee
@@ -20,7 +20,7 @@ define [
 		, 10
 
 		$scope.$watch((
-			() -> $scope.projects.filter((project) -> !project.tags? or project.tags.length == 0).length
+			() -> $scope.projects.filter((project) -> (!project.tags? or project.tags.length == 0) and !project.archived).length
 		), (newVal) -> $scope.nUntagged = newVal)
 
 		storedUIOpts = JSON.parse(localStorage("project_list"))


### PR DESCRIPTION
Some users complained about the number of uncategorized projects not matching what they expected (e.g. UI shows 4 uncategorized projects, but there are none). This was because the number of uncategorized projects was including deleted projects; this PR changes the "counting" method.