### PR TITLE
Support HTML encoded i18n

### DIFF
--- a/app/coffee/infrastructure/ExpressLocals.coffee
+++ b/app/coffee/infrastructure/ExpressLocals.coffee
@@ -11,6 +11,7 @@ async = require("async")
 Modules = require "./Modules"
 Url = require "url"
 PackageVersions = require "./PackageVersions"
+htmlEncoder = new require("node-html-encoder").Encoder("numerical")
 fingerprints = {}
 Path = require 'path'
 
@@ -151,9 +152,10 @@ module.exports = (app, webRouter, privateApiRouter, publicApiRouter)->
 		next()
 
 	webRouter.use (req, res, next)->
-		res.locals.translate = (key, vars = {}) ->
+		res.locals.translate = (key, vars = {}, htmlEncode = false) ->
 			vars.appName = Settings.appName
-			req.i18n.translate(key, vars)
+			str = req.i18n.translate(key, vars)
+			if htmlEncode then htmlEncoder.htmlEncode(str) else str
 		# Don't include the query string parameters, otherwise Google
 		# treats ?nocdn=true as the canonical version
 		res.locals.currentUrl = Url.parse(req.originalUrl).pathname

--- a/app/views/project/editor/editor.pug
+++ b/app/views/project/editor/editor.pug
@@ -82,7 +82,7 @@ div.full-size(
 			i.fa.fa-long-arrow-right
 		br
 		a.btn.btn-default.btn-xs(
-			tooltip-html="'"+translate('go_to_pdf_location_in_code')+"'"
+			tooltip-html="'"+translate('go_to_pdf_location_in_code', {}, true)+"'"
 			tooltip-placement="right"
 			tooltip-append-to-body="true"
 			ng-click="syncToCode()"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2728,6 +2728,11 @@
       "from": "node-forge@0.2.24",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.24.tgz"
     },
+    "node-html-encoder": {
+      "version": "0.0.2",
+      "from": "node-html-encoder@0.0.2",
+      "resolved": "https://registry.npmjs.org/node-html-encoder/-/node-html-encoder-0.0.2.tgz"
+    },
     "node-pre-gyp": {
       "version": "0.6.30",
       "from": "node-pre-gyp@0.6.30",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mongojs": "2.4.0",
     "mongoose": "4.11.4",
     "multer": "^0.1.8",
+    "node-html-encoder": "0.0.2",
     "nodemailer": "2.1.0",
     "nodemailer-sendgrid-transport": "^0.2.0",
     "nodemailer-ses-transport": "^1.3.0",


### PR DESCRIPTION
When used inside Angular-evaled attributes, translations can break the templates (by e.g. including a single-quote). This error will then potentially occur for every user in a given problematic language, which will then clutter Sentry with [Angular Lexer Errors](https://docs.angularjs.org/error/$parse/lexerr).

## How to reproduce
1. Go to sharelatex.com and change the language to French;
2. Open a project and compile it;
3. Hover the "Go to PDF location in code" button.

This will trigger errors in the dev console, and the button tooltip won't work (however, it works in the button above).

## Solution
Solution was to add a third optional parameter (defaulting to `false`)  to the `translate` Express local. This parameter, when `true`, will HTML encode the string (avoiding problematic characters such as the single quote). Method signature now is:

```
res.locals.translate = (key, vars = {}, htmlEncode = false) ->
```

Generally, we should force the HTML encoding when inserting the translation value into Angular expressions. e.g. 

```
tooltip-html="'"+translate('go_to_pdf_location_in_code', {}, true)+"'"
```

## How to test
Do the steps above to reproduce the bug; no errors should appear in the console and the tooltip should work fine.