### PR TITLE
Fix Cmaps path for future versions of PDF.js

### DIFF
--- a/app/views/project/editor.pug
+++ b/app/views/project/editor.pug
@@ -102,6 +102,7 @@ block requirejs
 	//- don't use cdn for workers
 	- var aceWorkerPath = buildJsPath(lib('ace'), {cdn:false,fingerprint:false})
 	- var pdfWorkerPath = buildJsPath('/libs/' + lib('pdfjs') + '/pdf.worker', {cdn:false,fingerprint:false})
+	- var pdfCMapsPath = buildJsPath('/libs/' + lib('pdfjs') + '/bcmaps/', {cdn:false,fingerprint:false})
 
 	//- We need to do .replace(/\//g, '\\/') do that '</script>' -> '<\/script>'
 	//- and doesn't prematurely end the script tag.
@@ -154,6 +155,7 @@ block requirejs
 		};
 		window.aceFingerprint = "#{fingerprint(jsPath + lib('ace') + '/ace.js')}"
 		window.aceWorkerPath = "#{aceWorkerPath}";
+		window.pdfCMapsPath = "#{pdfCMapsPath}"
 
 	script(
 		data-main=buildJsPath("ide.js", {fingerprint:false}),

--- a/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
+++ b/public/coffee/ide/pdfng/directives/pdfRenderer.coffee
@@ -15,7 +15,7 @@ define [
 
 			constructor: (@url, @options) ->
 				# set up external character mappings - needed for Japanese etc
-				window.PDFJS.cMapUrl = './bcmaps/'
+				window.PDFJS.cMapUrl = window.pdfCMapsPath # injected in editor.pug
 				window.PDFJS.cMapPacked = true
 
 				if window.location?.search?.indexOf("disable-font-face=true") >= 0


### PR DESCRIPTION
In v1.8.188 of PDF.js, fetching Cmaps was [refactored](https://github.com/mozilla/pdf.js/pull/8064) and moved the implementation out of the worker thread. This meant that the URL's relative path changed from `/js/libs/pdfjs-VERSION/` to the project root, breaking Cmap fetching. This PR fixes by providing the correct relative path to the Cmaps directory.