### PR TITLE
adding commands that appear in top 100 from SL-CLSI analysis

### DIFF
--- a/public/coffee/ide/editor/directives/aceEditor/auto-complete/CommandManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/auto-complete/CommandManager.coffee
@@ -1,10 +1,15 @@
 define [], () ->
 	noArgumentCommands = [
 		'item', 'hline', 'lipsum', 'centering', 'noindent', 'textwidth', 'draw',
-		'maketitle', 'newpage', 'verb', 'bibliography', 'fi', 'hfill', 'par',
-		'in', 'sum', 'cdot', 'alpha', 'ldots', 'else', 'linewidth', 'left',
-		'right', 'today', 'clearpage', 'newline', 'endinput', 'mu',
-		'tableofcontents', 'vfill', 'bigskip', 'fill', 'cleardoublepage'
+		'maketitle', 'newpage', 'verb', 'bibliography', 'hfill', 'par',
+		'in', 'sum', 'cdot', 'ldots', 'linewidth', 'left', 'right', 'today',
+		'clearpage', 'newline', 'endinput', 'tableofcontents', 'vfill',
+		'bigskip', 'fill', 'cleardoublepage', 'infty', 'leq', 'geq', 'times',
+		'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'varepsilon', 'zeta',
+		'eta', 'theta', 'vartheta', 'iota', 'kappa', 'lambda', 'mu', 'nu', 'xi',
+		'pi', 'varpi', 'rho', 'varrho', 'sigma', 'varsigma', 'tau', 'upsilon',
+		'phi', 'varphi', 'chi', 'psi', 'omega', 'Gamma', 'Delta', 'Theta',
+		'Lambda', 'Xi', 'Pi', 'Sigma', 'Upsilon', 'Phi', 'Psi', 'Omega'
 	]
 	singleArgumentCommands = [
 		'chapter', 'usepackage', 'section', 'label', 'textbf', 'subsection',
@@ -13,11 +18,12 @@ define [], () ->
 		'hspace', 'bibitem', 'url', 'large', 'subsubsection', 'textsc', 'date',
 		'footnote', 'small', 'thanks', 'underline', 'graphicspath', 'pageref',
 		'section*', 'subsection*', 'subsubsection*', 'sqrt', 'text',
-		'normalsize', 'Large', 'paragraph', 'pagestyle', 'thispagestyle',
-		'bibliographystyle'
+		'normalsize', 'footnotesize', 'Large', 'paragraph', 'pagestyle',
+		'thispagestyle', 'bibliographystyle', 'hat'
 	]
 	doubleArgumentCommands = [
-		'newcommand', 'frac', 'renewcommand', 'setlength', 'href', 'newtheorem'
+		'newcommand', 'frac', 'dfrac', 'renewcommand', 'setlength', 'href',
+		'newtheorem'
 	]
 	tripleArgumentCommands = [
 		'addcontentsline', 'newacronym', 'multicolumn'
@@ -25,12 +31,12 @@ define [], () ->
 	special = ['LaTeX', 'TeX']
 
 	rawCommands = [].concat(
-						noArgumentCommands,
-						singleArgumentCommands,
-						doubleArgumentCommands,
-						tripleArgumentCommands,
-						special
-					)
+		noArgumentCommands,
+		singleArgumentCommands,
+		doubleArgumentCommands,
+		tripleArgumentCommands,
+		special
+	)
 
 	noArgumentCommands = for cmd in noArgumentCommands
 		{


### PR DESCRIPTION
Also, since there are a few Greek letters in the top 100, I thought for completeness we should all them all. (Note: I omitted commands in the top 100 if they require a package to be loaded e.g. `mathcal`).