### PR TITLE
include the options in the project state hash

### DIFF
--- a/app/coffee/Features/Compile/ClsiManager.coffee
+++ b/app/coffee/Features/Compile/ClsiManager.coffee
@@ -127,7 +127,7 @@ module.exports = ClsiManager =
 
 			if options.incrementalCompilesEnabled or options.syncType? # new way, either incremental or full
 				timer = new Metrics.Timer("editor.compile-getdocs-redis")
-				ClsiManager.getContentFromDocUpdaterIfMatch project_id, project, (error, projectStateHash, docUpdaterDocs) ->
+				ClsiManager.getContentFromDocUpdaterIfMatch project_id, project, options, (error, projectStateHash, docUpdaterDocs) ->
 					timer.done()
 					return callback(error) if error?
 					logger.log project_id: project_id, projectStateHash: projectStateHash, docs: docUpdaterDocs?, "checked project state"
@@ -150,8 +150,8 @@ module.exports = ClsiManager =
 					return callback(error) if error?
 					ClsiManager._finaliseRequest project_id, options, project, docs, files, callback
 
-	getContentFromDocUpdaterIfMatch: (project_id, project, callback = (error, projectStateHash, docs) ->) ->
-		ClsiStateManager.computeHash project, (error, projectStateHash) ->
+	getContentFromDocUpdaterIfMatch: (project_id, project, options, callback = (error, projectStateHash, docs) ->) ->
+		ClsiStateManager.computeHash project, options, (error, projectStateHash) ->
 			return callback(error) if error?
 			DocumentUpdaterHandler.getProjectDocsIfMatch project_id, projectStateHash, (error, docs) ->
 				return callback(error) if error?

--- a/app/coffee/Features/Compile/ClsiStateManager.coffee
+++ b/app/coffee/Features/Compile/ClsiStateManager.coffee
@@ -22,10 +22,14 @@ buildState = (s) ->
 
 module.exports = ClsiStateManager =
 
-	computeHash: (project, callback = (err, hash) ->) ->
+	computeHash: (project, options, callback = (err, hash) ->) ->
 		ProjectEntityHandler.getAllEntitiesFromProject project, (err, docs, files) ->
 			fileList = ("#{f.file._id}:#{f.file.rev}:#{f.file.created}:#{f.path}" for f in files or [])
 			docList = ("#{d.doc._id}:#{d.path}" for d in docs or [])
 			sortedEntityList = [docList..., fileList...].sort()
-			hash = buildState(sortedEntityList.join("\n"))
+			# ignore the isAutoCompile options as it doesn't affect the
+			# output, but include all other options e.g. draft
+			optionsList = ("option #{key}:#{value}" for key, value of options or {} when not (key in ['isAutoCompile']))
+			sortedOptionsList = optionsList.sort()
+			hash = buildState([sortedEntityList..., sortedOptionsList...].join("\n"))
 			callback(null, hash)

--- a/test/UnitTests/coffee/Compile/ClsiManagerTests.coffee
+++ b/test/UnitTests/coffee/Compile/ClsiManagerTests.coffee
@@ -13,7 +13,7 @@ describe "ClsiManager", ->
 			setServerId: sinon.stub().callsArgWith(2)
 			_getServerId:sinon.stub()
 		@ClsiStateManager =
-			computeHash: sinon.stub().callsArgWith(1, null, "01234567890abcdef")
+			computeHash: sinon.stub().callsArgWith(2, null, "01234567890abcdef")
 		@ClsiFormatChecker =
 			checkRecoursesForProblems:sinon.stub().callsArgWith(1)
 		@ClsiManager = SandboxedModule.require modulePath, requires:
@@ -229,7 +229,7 @@ describe "ClsiManager", ->
 
 		describe "with the incremental compile option", ->
 			beforeEach (done) ->
-				@ClsiStateManager.computeHash = sinon.stub().callsArgWith(1, null, @project_state_hash = "01234567890abcdef")
+				@ClsiStateManager.computeHash = sinon.stub().callsArgWith(2, null, @project_state_hash = "01234567890abcdef")
 				@DocumentUpdaterHandler.getProjectDocsIfMatch = sinon.stub().callsArgWith(2, null, [{_id:@doc_1._id, lines:  @doc_1.lines, v: 123}])
 				@ProjectEntityHandler.getAllDocPathsFromProject = sinon.stub().callsArgWith(1, null, {"mock-doc-id-1":"main.tex"})
 				@ClsiManager._buildRequest @project_id, {timeout:100, incrementalCompilesEnabled:true}, (error, request) =>

--- a/test/UnitTests/coffee/Compile/ClsiStateManagerTests.coffee
+++ b/test/UnitTests/coffee/Compile/ClsiStateManagerTests.coffee
@@ -12,6 +12,7 @@ describe "ClsiStateManager", ->
 			"../Project/ProjectEntityHandler": @ProjectEntityHandler = {}
 			"logger-sharelatex": @logger = { log: sinon.stub(), error: sinon.stub(), warn: sinon.stub() }
 		@project = "project"
+		@options = {"draft":true,"isAutoCompile":false}
 		@callback = sinon.stub()
 
 	describe "computeHash", ->
@@ -25,24 +26,24 @@ describe "ClsiStateManager", ->
 				{path: "/folder/fig2.pdf", file: {_id: "file-id-2", rev: 456, created: "bbbbbb"}}
 			]
 			@ProjectEntityHandler.getAllEntitiesFromProject = sinon.stub().callsArgWith(1, null, @docs, @files)
-			@ClsiStateManager.computeHash @project, (err, hash) =>
+			@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 				@hash0 = hash
 				done()
 
 		describe "with a sample project", ->
 			beforeEach ->
-				@ClsiStateManager.computeHash @project, @callback
+				@ClsiStateManager.computeHash @project, @options, @callback
 
 			it "should call the callback with a hash value", ->
 				@callback
-					.calledWith(null, "9c2c2428e4147db63cacabf6f357af483af6551d")
+					.calledWith(null, "21b1ab73aa3892bec452baf8ffa0956179e1880f")
 					.should.equal true
 
 		describe "when the files and docs are in a different order", ->
 			beforeEach ->
 				[@docs[0], @docs[1]] = [@docs[1], @docs[0]]
 				[@files[0], @files[1]] = [@files[1], @files[0]]
-				@ClsiStateManager.computeHash @project, @callback
+				@ClsiStateManager.computeHash @project, @options, @callback
 
 			it "should call the callback with the same hash value", ->
 				@callback
@@ -52,7 +53,7 @@ describe "ClsiStateManager", ->
 		describe "when a doc is renamed", ->
 			beforeEach (done) ->
 				@docs[0].path = "/new.tex"
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -64,7 +65,7 @@ describe "ClsiStateManager", ->
 		describe "when a file is renamed", ->
 			beforeEach (done) ->
 				@files[0].path = "/newfigure.pdf"
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -76,7 +77,7 @@ describe "ClsiStateManager", ->
 		describe "when a doc is added", ->
 			beforeEach (done) ->
 				@docs.push { path: "/newdoc.tex", doc: {_id: "newdoc-id"}}
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -88,7 +89,7 @@ describe "ClsiStateManager", ->
 		describe "when a file is added", ->
 			beforeEach (done) ->
 				@files.push { path: "/newfile.tex", file: {_id: "newfile-id", rev: 123}}
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -100,7 +101,7 @@ describe "ClsiStateManager", ->
 		describe "when a doc is removed", ->
 			beforeEach (done) ->
 				@docs.pop()
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -112,7 +113,7 @@ describe "ClsiStateManager", ->
 		describe "when a file is removed", ->
 			beforeEach (done) ->
 				@files.pop()
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -124,7 +125,7 @@ describe "ClsiStateManager", ->
 		describe "when a file's revision is updated", ->
 			beforeEach (done) ->
 				@files[0].file.rev++
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -137,7 +138,7 @@ describe "ClsiStateManager", ->
 		describe "when a file's date is updated", ->
 			beforeEach (done) ->
 				@files[0].file.created = "zzzzzz"
-				@ClsiStateManager.computeHash @project, (err, hash) =>
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
 					@hash1 = hash
 					done()
 
@@ -146,3 +147,25 @@ describe "ClsiStateManager", ->
 					.neverCalledWith(null, @hash0)
 					.should.equal true
 
+		describe "when the compile options are changed", ->
+			beforeEach (done) ->
+				@options.draft = !@options.draft
+				@ClsiStateManager.computeHash @project, @options, (err, hash) =>
+					@hash1 = hash
+					done()
+
+			it "should call the callback with a different hash value", ->
+				@callback
+					.neverCalledWith(null, @hash0)
+					.should.equal true
+
+
+		describe "when the isAutoCompile option is changed", ->
+			beforeEach () ->
+				@options.isAutoCompile = !@options.isAutoCompile
+				@ClsiStateManager.computeHash @project, @options, @callback
+
+			it "should call the callback with the same hash value", ->
+				@callback
+					.calledWith(null, @hash0)
+					.should.equal true


### PR DESCRIPTION
only do incremental compiles when the compile options are the unchanged (to prevent problems where the compile options affect the input files, e.g. when we do some rewriting in the clsi)