### PR TITLE
add ol-style.css to fingerprint list

### DIFF
--- a/app/coffee/infrastructure/ExpressLocals.coffee
+++ b/app/coffee/infrastructure/ExpressLocals.coffee
@@ -45,6 +45,7 @@ pathList = [
 	["#{jsPath}libs/#{pdfjs}/pdf.worker.js"]
 	["#{jsPath}libs/#{pdfjs}/compatibility.js"]
 	["/stylesheets/style.css"]
+	["/stylesheets/ol-style.css"]
 ]
 
 for paths in pathList


### PR DESCRIPTION
Need to add ol-style to the fingerprint list - we're getting a lot of errors "No fingerprint for file: /stylesheets/ol-style.css"
