### PR TITLE
Fix UX issues in email autocompletion in share modal

### DIFF
--- a/app/views/project/editor/share.pug
+++ b/app/views/project/editor/share.pug
@@ -147,6 +147,8 @@ script(type='text/ng-template', id='shareProjectModalTemplate')
 						| #{translate("cannot_invite_non_user")}
 					span(ng-switch-when="cannot_invite_self")
 						| #{translate("cannot_invite_self")}
+					span(ng-switch-when="invalid_email")
+						| #{translate("invalid_email")}
 					span(ng-switch-default)
 						| #{translate("generic_something_went_wrong")}
 		button.btn.btn-default(

--- a/app/views/project/editor/share.pug
+++ b/app/views/project/editor/share.pug
@@ -71,6 +71,7 @@ script(type='text/ng-template', id='shareProjectModalTemplate')
 							focus-on="open"
 							display-property="display"
 							add-on-paste="true"
+							add-on-enter="false"
 							replace-spaces-with-dashes="false"
 							type="email"
 						)

--- a/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
+++ b/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
@@ -130,7 +130,7 @@ define [
 						.catch (err) ->
 							$scope.state.inflight = false
 							$scope.state.error = true
-							if (err.status? and err.status == 400)
+							if err.status? and err.status == 400
 								$scope.state.errorReason = 'invalid_email'
 							else
 								$scope.state.errorReason = null

--- a/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
+++ b/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
@@ -127,10 +127,13 @@ define [
 								# with new collaborator information.
 								addNextMember()
 							, 0
-						.catch () ->
+						.catch (err) ->
 							$scope.state.inflight = false
 							$scope.state.error = true
-							$scope.state.errorReason = null
+							if (err.status? and err.status == 400)
+								$scope.state.errorReason = 'invalid_email'
+							else
+								$scope.state.errorReason = null
 
 			$timeout addMembers, 50 # Give email list a chance to update
 

--- a/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
+++ b/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
@@ -39,7 +39,7 @@ define [
 					$scope.autocompleteContacts = data.contacts or []
 					for contact in $scope.autocompleteContacts
 						if contact.type == "user"
-							if contact.last_name == "" and contact.first_name = contact.email.split("@")[0]
+							if contact.last_name and contact.first_name == contact.email.split("@")[0]
 								# User has not set their proper name so use email as canonical display property
 								contact.display = contact.email
 							else

--- a/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
+++ b/public/coffee/ide/share/controllers/ShareProjectModalController.coffee
@@ -39,7 +39,7 @@ define [
 					$scope.autocompleteContacts = data.contacts or []
 					for contact in $scope.autocompleteContacts
 						if contact.type == "user"
-							if contact.last_name and contact.first_name == contact.email.split("@")[0]
+							if contact.last_name == "" and contact.first_name == contact.email.split("@")[0]
 								# User has not set their proper name so use email as canonical display property
 								contact.display = contact.email
 							else


### PR DESCRIPTION
### Description

This fixes a few UX issues in the email autocompletion:

- Pressing enter with a partially completed email would not select the suggestion, but insert the partial email address
- Users who had not set a last name would see `undefined` as the suggested user's name
- Submitting an invalid email to the server would not show a useful error message

#### Screenshots

[GIF!](https://user-images.githubusercontent.com/424411/30114367-94817692-930f-11e7-9096-b0c2ee0126a0.gif)

#### Related issues

https://github.com/overleaf/sharelatex/issues/66

### Review

The error message I went with was "An email address is invalid". This is a bit ambiguous, but due to the way in which we submit emails, we can only be sure about 1 invalid email (and there may be multiple submitted). We should look into refactoring this in the future.

### Deployment

- [x] Added `invalid_email` translation