### PR TITLE
suppress incremental compile after errors

### DIFF
--- a/app/coffee/Features/Compile/ClsiManager.coffee
+++ b/app/coffee/Features/Compile/ClsiManager.coffee
@@ -129,10 +129,15 @@ module.exports = ClsiManager =
 				timer = new Metrics.Timer("editor.compile-getdocs-redis")
 				ClsiManager.getContentFromDocUpdaterIfMatch project_id, project, options, (error, projectStateHash, docUpdaterDocs) ->
 					timer.done()
-					return callback(error) if error?
-					logger.log project_id: project_id, projectStateHash: projectStateHash, docs: docUpdaterDocs?, "checked project state"
+					if error?
+						logger.error err: error, project_id: project_id, "error checking project state"
+						# note: we don't bail out when there's an error getting
+						# incremental files from the docupdater, we just fall back
+						# to a normal compile below
+					else
+						logger.log project_id: project_id, projectStateHash: projectStateHash, docs: docUpdaterDocs?, "checked project state"
 					# see if we can send an incremental update to the CLSI
-					if docUpdaterDocs? and options.syncType isnt "full"
+					if docUpdaterDocs? and options.syncType isnt "full" and not error?
 						# Workaround: for now, always flush project to mongo on compile
 						# until we have automatic periodic flushing on the docupdater
 						# side, to prevent documents staying in redis too long.

--- a/app/coffee/Features/Compile/ClsiManager.coffee
+++ b/app/coffee/Features/Compile/ClsiManager.coffee
@@ -137,7 +137,7 @@ module.exports = ClsiManager =
 					else
 						logger.log project_id: project_id, projectStateHash: projectStateHash, docs: docUpdaterDocs?, "checked project state"
 					# see if we can send an incremental update to the CLSI
-					if docUpdaterDocs? and options.syncType isnt "full" and not error?
+					if docUpdaterDocs? and (options.syncType isnt "full") and not error?
 						# Workaround: for now, always flush project to mongo on compile
 						# until we have automatic periodic flushing on the docupdater
 						# side, to prevent documents staying in redis too long.

--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -105,7 +105,9 @@ define [
 				rootDoc_id: options.rootDocOverride_id or null
 				draft: $scope.draft
 				check: checkType
-				incrementalCompilesEnabled: window.user?.betaProgram
+				# use incremental compile for beta users but revert to a full
+				# compile if there is a server error
+				incrementalCompilesEnabled: window.user?.betaProgram and not $scope.pdf.error
 				_csrf: window.csrfToken
 			}, {params: params}
 


### PR DESCRIPTION
to allow recovery from problems in the incremental updates, do a full compile after any server error from the clsi or error getting incremental files from the docupdater.

Currently, if there is an error from either of those we keep trying the incremental request - with no way for the user to recover.