### PR TITLE
Improve "infrequent edit" auto compile UX

### DIFF
--- a/public/coffee/ide/pdf/controllers/PdfController.coffee
+++ b/public/coffee/ide/pdf/controllers/PdfController.coffee
@@ -80,8 +80,11 @@ define [
 			return if autoCompileTimeout
 
 			timeSinceLastCompile = Date.now() - $scope.recompiledAt
+			# If time is non-monotonic, assume that the user's system clock has been
+			# changed and continue with recompile
+			isTimeNonMonotonic = timeSinceLastPoll < 0;
 
-			if timeSinceLastCompile >= AUTO_COMPILE_TIMEOUT
+			if isTimeNonMonotonic || timeSinceLastCompile >= AUTO_COMPILE_TIMEOUT
 				if (!ide.$scope.hasLintingError)
 					$scope.recompile(isBackgroundAutoCompile: true)
 			else


### PR DESCRIPTION
### Description

Extends #591. Improves auto-compile by checking last recompile time instead of a simple debounce. This means users doing "infrequent edits" will trigger an auto-compile faster, without waiting for the debounce timer to expire.

#### Related PR

⚠️ Base branch is `as-client-autocompile`, not `master`. Once #591 is merged, will change to `master`.