### PR TITLE
clear docupdater project state in deleteAuxFiles

### DIFF
--- a/app/coffee/Features/Compile/ClsiManager.coffee
+++ b/app/coffee/Features/Compile/ClsiManager.coffee
@@ -62,7 +62,13 @@ module.exports = ClsiManager =
 		opts =
 			url:compilerUrl
 			method:"DELETE"
-		ClsiManager._makeRequest project_id, opts, callback
+		ClsiManager._makeRequest project_id, opts, (clsiError) ->
+			# always clear the project state from the docupdater, even if there
+			# was a problem with the request to the clsi
+			DocumentUpdaterHandler.clearProjectState project_id, (docUpdaterError) ->
+				error = clsiError or docUpdaterError
+				return callback(error) if error?
+				callback()
 
 	_makeRequest: (project_id, opts, callback)->
 		ClsiCookieManager.getCookieJar project_id, (err, jar)->

--- a/app/coffee/Features/DocumentUpdater/DocumentUpdaterHandler.coffee
+++ b/app/coffee/Features/DocumentUpdater/DocumentUpdaterHandler.coffee
@@ -155,7 +155,7 @@ module.exports = DocumentUpdaterHandler =
 
 	clearProjectState: (project_id, callback = (error) ->) ->
 		timer = new metrics.Timer("clear-project-state")
-		url = "#{settings.apis.documentupdater.url}/project/#{project_id}/clear"
+		url = "#{settings.apis.documentupdater.url}/project/#{project_id}/clearState"
 		logger.log project_id:project_id, "clearing project state from document updater"
 		request.post url, (error, res)->
 			timer.done()

--- a/app/coffee/Features/DocumentUpdater/DocumentUpdaterHandler.coffee
+++ b/app/coffee/Features/DocumentUpdater/DocumentUpdaterHandler.coffee
@@ -153,6 +153,22 @@ module.exports = DocumentUpdaterHandler =
 				logger.error project_id:project_id, url: url, "doc updater returned a non-success status code: #{res.statusCode}"
 				callback new Error("doc updater returned a non-success status code: #{res.statusCode}")
 
+	clearProjectState: (project_id, callback = (error) ->) ->
+		timer = new metrics.Timer("clear-project-state")
+		url = "#{settings.apis.documentupdater.url}/project/#{project_id}/clear"
+		logger.log project_id:project_id, "clearing project state from document updater"
+		request.post url, (error, res)->
+			timer.done()
+			if error?
+				logger.error err:error, url:url, project_id:project_id, "error clearing project state from doc updater"
+				return callback(error)
+			else if res.statusCode is 200
+				logger.log project_id:project_id, "cleared project state from doc updater"
+				callback()
+			else
+				logger.error project_id:project_id, url: url, "doc updater returned a non-success status code: #{res.statusCode}"
+				callback new Error("doc updater returned a non-success status code: #{res.statusCode}")
+
 	acceptChanges: (project_id, doc_id, change_ids = [], callback = (error) ->) ->
 		timer = new metrics.Timer("accept-changes")
 		reqSettings =

--- a/test/UnitTests/coffee/Compile/ClsiManagerTests.coffee
+++ b/test/UnitTests/coffee/Compile/ClsiManagerTests.coffee
@@ -125,6 +125,7 @@ describe "ClsiManager", ->
 	describe "deleteAuxFiles", ->
 		beforeEach ->
 			@ClsiManager._makeRequest = sinon.stub().callsArg(2)
+			@DocumentUpdaterHandler.clearProjectState = sinon.stub().callsArg(1)
 			
 		describe "with the standard compileGroup", ->
 			beforeEach ->
@@ -133,6 +134,11 @@ describe "ClsiManager", ->
 			it "should call the delete method in the standard CLSI", ->
 				@ClsiManager._makeRequest
 					.calledWith(@project_id, { method:"DELETE", url:"#{@settings.apis.clsi.url}/project/#{@project_id}/user/#{@user_id}"})
+					.should.equal true
+
+			it "should clear the project state from the docupdater", ->
+				@DocumentUpdaterHandler.clearProjectState
+					.calledWith(@project_id)
 					.should.equal true
 
 			it "should call the callback", ->

--- a/test/UnitTests/coffee/DocumentUpdater/DocumentUpdaterHandlerTests.coffee
+++ b/test/UnitTests/coffee/DocumentUpdater/DocumentUpdaterHandlerTests.coffee
@@ -293,6 +293,42 @@ describe 'DocumentUpdaterHandler', ->
 					.alwaysCalledWithExactly()
 					.should.equal true
 
+
+	describe "clearProjectState", ->
+		beforeEach ->
+			@callback = sinon.stub()
+
+		describe "successfully", ->
+			beforeEach ->
+				@request.post = sinon.stub().callsArgWith(1, null, {statusCode: 200})
+				@handler.clearProjectState @project_id, @callback
+
+			it 'should clear the project state from the document updater', ->
+				url = "#{@settings.apis.documentupdater.url}/project/#{@project_id}/clear"
+				@request.post.calledWith(url).should.equal true
+
+			it "should call the callback", ->
+				@callback.calledWithExactly().should.equal true
+
+		describe "when the document updater API returns an error", ->
+			beforeEach ->
+				@request.get = sinon.stub().callsArgWith(1, @error = new Error("something went wrong"), null, null)
+				@handler.getProjectDocsIfMatch @project_id, @project_state_hash, @callback
+
+			it "should return an error to the callback", ->
+				@callback.calledWith(@error).should.equal true
+
+		describe "when the document updater returns a conflict error code", ->
+			beforeEach ->
+				@request.get = sinon.stub().callsArgWith(1, null, { statusCode: 409 }, "Conflict")
+				@handler.getProjectDocsIfMatch @project_id, @project_state_hash, @callback
+
+			it "should return the callback with no documents", ->
+				@callback
+					.alwaysCalledWithExactly()
+					.should.equal true
+
+
 	describe "acceptChanges", ->
 		beforeEach ->
 			@change_id = "mock-change-id-1"


### PR DESCRIPTION
call the endpoint in the docupdater to clear the project state when the user clicks the trash can, allows us to recover if the state is out of sync.