### PR TITLE
Raising the limit on safari regex count

### DIFF
--- a/public/coffee/ide/editor/directives/aceEditor/auto-complete/CommandManager.coffee
+++ b/public/coffee/ide/editor/directives/aceEditor/auto-complete/CommandManager.coffee
@@ -79,7 +79,7 @@ define [], () ->
 			# hacky solution: limit iterations
 			limit = null
 			if window?._ide?.browserIsSafari
-				limit = 100
+				limit = 5000
 
 			# fully formed commands
 			realCommands = []


### PR DESCRIPTION
This allows editor to pick up more than 100 commands (previous limit) used in files. Now bumped up to 5000.