### PR TITLE
Remove extra security headers

### DIFF
--- a/app/coffee/infrastructure/Server.coffee
+++ b/app/coffee/infrastructure/Server.coffee
@@ -153,6 +153,9 @@ webRouter.use (req, res, next) ->
 		dnsPrefetchControl: false
 		referrerPolicy: { policy: 'origin-when-cross-origin' }
 		noCache: isLoggedIn || isProjectPage
+		noSniff: false
+		hsts: false
+		frameguard: false
 	})(req, res, next)
 
 profiler = require "v8-profiler"

--- a/test/acceptance/coffee/SecurityHeadersTests.coffee
+++ b/test/acceptance/coffee/SecurityHeadersTests.coffee
@@ -5,9 +5,6 @@ request = require('./helpers/request')
 
 assert_has_common_headers = (response) ->
 	headers = response.headers
-	assert.equal(headers['x-frame-options'], 'SAMEORIGIN')
-	assert.equal(headers['strict-transport-security'], 'max-age=15552000; includeSubDomains')
-	assert.equal(headers['x-content-type-options'], 'nosniff')
 	assert.equal(headers['x-download-options'], 'noopen')
 	assert.equal(headers['x-xss-protection'], '1; mode=block')
 	assert.equal(headers['referrer-policy'], 'origin-when-cross-origin')


### PR DESCRIPTION
Don't add `Strict-Transport-Security`, `X-Content-Type-Options` and `X-Frame-Options` headers.